### PR TITLE
Constancy-based flow shader

### DIFF
--- a/shaders/cMedian.fx
+++ b/shaders/cMedian.fx
@@ -118,7 +118,7 @@ void Median_PS(in float4 Position : SV_POSITION, in float4 Offsets[3] : TEXCOORD
     OutputColor0 = Median_9(Sample[0], Sample[1], Sample[2],
                             Sample[3], Sample[4], Sample[5],
                             Sample[6], Sample[7], Sample[8]);
-    }
+}
 
 technique cMedian
 {

--- a/shaders/cMotionBlur.fx
+++ b/shaders/cMotionBlur.fx
@@ -85,8 +85,11 @@ namespace Shared_Resources_Motion_Blur
     TEXTURE(Render_Common_2, BUFFER_SIZE_2, RG16F, 1)
     SAMPLER(Sample_Common_2, Render_Common_2)
 
-    TEXTURE(Render_Common_3, BUFFER_SIZE_3, RG16F, 1)
-    SAMPLER(Sample_Common_3, Render_Common_3)
+    TEXTURE(Render_Common_3_A, BUFFER_SIZE_3, RG16F, 1)
+    SAMPLER(Sample_Common_3_A, Render_Common_3_A)
+
+    TEXTURE(Render_Common_3_B, BUFFER_SIZE_3, RG16F, 1)
+    SAMPLER(Sample_Common_3_B, Render_Common_3_B)
 
     TEXTURE(Render_Common_4, BUFFER_SIZE_4, RG16F, 1)
     SAMPLER(Sample_Common_4, Render_Common_4)
@@ -112,7 +115,7 @@ namespace Motion_Blur
         > = DEFAULT;
 
     OPTION(float, _Constraint, "slider", "Optical flow", "Motion constraint", 0.0, 1.0, 0.5)
-    OPTION(float, _MipBias, "slider", "Optical flow", "Optical flow mipmap bias", 0.0, 8.0, 5.5)
+    OPTION(float, _MipBias, "slider", "Optical flow", "Optical flow mipmap bias", 0.0, 8.0, 0.0)
     OPTION(float, _BlendFactor, "slider", "Optical flow", "Temporal blending factor", 0.0, 0.9, 0.1)
 
     OPTION(bool, _NormalMode, "radio", "Main", "Estimate normals", 0.0, 1.0, false)
@@ -149,10 +152,12 @@ namespace Motion_Blur
     TEXTURE(Render_Common_1_C, BUFFER_SIZE_1, RG16F, 9)
     SAMPLER(Sample_Common_1_C, Render_Common_1_C)
 
-    TEXTURE(Render_Optical_Flow, BUFFER_SIZE_1, RG16F, 1)
+    TEXTURE(Render_Optical_Flow, BUFFER_SIZE_1, RG16F, 9)
     SAMPLER(Sample_Optical_Flow, Render_Optical_Flow)
 
-    // Vertex Shaders
+    /*
+        [Vertex Shaders]
+    */
 
     void Basic_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float2 TexCoord : TEXCOORD0)
     {
@@ -195,6 +200,32 @@ namespace Motion_Blur
         }
     }
 
+    void Blur_0_P_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[7] : TEXCOORD0)
+    {
+        float2 CoordVS = 0.0;
+        Basic_VS(ID, Position, CoordVS);
+        TexCoords[0] = CoordVS.xyxy;
+
+        for(int i = 1; i < 4; i++)
+        {
+            TexCoords[i] = CoordVS.xyyy + (BlurOffsets[i].xyzw / BUFFER_SIZE_3.xyyy);
+            TexCoords[i + 3] = CoordVS.xyyy - (BlurOffsets[i].xyzw / BUFFER_SIZE_3.xyyy);
+        }
+    }
+
+    void Blur_1_P_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[7] : TEXCOORD0)
+    {
+        float2 CoordVS = 0.0;
+        Basic_VS(ID, Position, CoordVS);
+        TexCoords[0] = CoordVS.xyxy;
+
+        for(int i = 1; i < 4; i++)
+        {
+            TexCoords[i] = CoordVS.xxxy + (BlurOffsets[i].yzwx / BUFFER_SIZE_3.xxxy);
+            TexCoords[i + 3] = CoordVS.xxxy - (BlurOffsets[i].yzwx / BUFFER_SIZE_3.xxxy);
+        }
+    }
+
     void Sample_3x3_VS(in uint ID, in float2 TexelSize, out float4 Position, out float4 TexCoords[3])
     {
         float2 CoordVS = 0.0;
@@ -229,11 +260,57 @@ namespace Motion_Blur
         TexCoords[1] = CoordVS.xxyy + (float4(-0.5, 0.5, -1.5, 1.5) / BUFFER_SIZE_1.xxyy);
     }
 
-    // Pixel Shaders
+    /*
+        [Pixel Shaders]
 
-    // Generate normals: https://github.com/crosire/reshade-shaders/blob/slim/Shaders/DisplayDepth.fx [MIT]
-    // Normal encodes: https://knarkowicz.wordpress.com/2014/04/16/octahedron-normal-vector-encoding/
-    // Contour pass: https://github.com/keijiro/KinoContour [MIT]
+        [1] Generate normals
+            https://github.com/crosire/reshade-shaders/blob/slim/Shaders/DisplayDepth.fx
+
+        [2] Normal encoding
+            https://knarkowicz.wordpress.com/2014/04/16/octahedron-normal-vector-encoding/
+
+        [3] Polar-coordinate diagram
+            https://opg.optica.org/josaa/fulltext.cfm?uri=josaa-37-11-1721&id=440913
+
+                @article{buzzelli2020arc,
+                    title = {ARC: Angle-Retaining Chromaticity diagram for color constancy error analysis},
+                    author = {Marco Buzzelli and Simone Bianco and Raimondo Schettini},
+                    journal = {J. Opt. Soc. Am. A},
+                    number = {11},
+                    pages = {1721--1730},
+                    publisher = {OSA},
+                    volume = {37},
+                    month = {Nov},
+                    year = {2020},
+                    doi = {10.1364/JOSAA.398692}
+                }
+
+        [4] Horn-Schunck Optical Flow
+            https://github.com/Dtananaev/cv_opticalFlow
+
+                Copyright (c) 2014-2015, Denis Tananaev All rights reserved.
+
+                Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+                Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+                Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+                documentation and/or other materials provided with the distribution.
+
+                THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+                INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+                DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+                EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+                LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+                STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+                ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+        [5] Robert's cross operator
+            https://homepages.inf.ed.ac.uk/rbf/HIPR2/roberts.htm
+
+        [6] Prewitt compass operator
+            https://homepages.inf.ed.ac.uk/rbf/HIPR2/prewitt.htm
+    */
 
     float3 Get_Screen_Space_Normal(float2 TexCoord)
     {
@@ -282,7 +359,10 @@ namespace Motion_Blur
         else
         {
             float4 Frame = max(tex2D(Sample_Color, TexCoord), exp2(-10.0));
-            Color.xy = saturate(Frame.xy / dot(Frame.rgb, 1.0));
+            // Convert RGB into ARC's polar coordinates [3]
+            // Append "FP16_MINIMUM" to avoid dividing by zero
+            Color.x = saturate(acos(dot(Frame.rgb, 1.0) / (sqrt(3.0) * length(Frame.rgb))));
+            Color.y = atan2(dot(Frame.gb, float2(sqrt(3.0), -sqrt(3.0))), dot(Frame.rgb, float3(2.0, -1.0, -1.0)) + FP16_MINIMUM);
         }
     }
 
@@ -356,11 +436,20 @@ namespace Motion_Blur
         Gaussian_Blur(Shared_Resources_Motion_Blur::Sample_Common_1_B, TexCoords, true, OutputColor0);
     }
 
+    // Turn the packed angle vector into its respective unit vectors
+    float3 HS_Units_2D(sampler2D Source, float2 TexCoord)
+    {
+        float3 Color = tex2D(Source, TexCoord).xyz;
+        sincos(Color.y, Color.z, Color.y);
+        Color.zy = saturate(Color.zy * 0.5 + 0.5);
+        return Color;
+    }
+
     void Derivatives_Z_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
     {
-        float2 Current = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoord).xy;
-        float2 Previous = tex2D(Sample_Common_1_C, TexCoord).xy;
-        OutputColor0 = dot(Current - Previous, 1.0);
+        float3 Current = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoord);
+        float3 Previous = HS_Units_2D(Sample_Common_1_C, TexCoord);
+        OutputColor0 = dot(Current - Previous, float3(0.95, 0.025, 0.025));
     }
 
     void Derivatives_XY_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
@@ -370,42 +459,29 @@ namespace Motion_Blur
         // A0     A1
         // A2     B0
         //   C0 C1
-        float2 A0 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].xw).xy * 4.0; // <-1.5, +0.5>
-        float2 A1 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].yw).xy * 4.0; // <+1.5, +0.5>
-        float2 A2 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].xz).xy * 4.0; // <-1.5, -0.5>
-        float2 B0 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].yz).xy * 4.0; // <+1.5, -0.5>
-        float2 B1 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].xw).xy * 4.0; // <-0.5, +1.5>
-        float2 B2 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].yw).xy * 4.0; // <+0.5, +1.5>
-        float2 C0 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].xz).xy * 4.0; // <-0.5, -1.5>
-        float2 C1 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].yz).xy * 4.0; // <+0.5, -1.5>
+        float3 A0 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].xw) * 4.0; // <-1.5, +0.5>
+        float3 A1 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].yw) * 4.0; // <+1.5, +0.5>
+        float3 A2 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].xz) * 4.0; // <-1.5, -0.5>
+        float3 B0 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].yz) * 4.0; // <+1.5, -0.5>
+        float3 B1 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].xw) * 4.0; // <-0.5, +1.5>
+        float3 B2 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].yw) * 4.0; // <+0.5, +1.5>
+        float3 C0 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].xz) * 4.0; // <-0.5, -1.5>
+        float3 C1 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].yz) * 4.0; // <+0.5, -1.5>
 
         OutputColor0 = 0.0;
-        float2 Ix = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
-        float2 Iy = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
-        OutputColor0.x = dot(Ix, 1.0);
-        OutputColor0.y = dot(Iy, 1.0);
+        float3 Ix = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
+        float3 Iy = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
+        OutputColor0.x = dot(Ix, float3(0.95, 0.025, 0.025));
+        OutputColor0.y = dot(Iy, float3(0.95, 0.025, 0.025));
     }
-
-    /*
-        https://github.com/Dtananaev/cv_opticalFlow
-
-        Copyright (c) 2014-2015, Denis Tananaev All rights reserved.
-
-        Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-        Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-        Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-    */
 
     #define COARSEST_LEVEL 5
 
+    // Calculate first level of Horn-Schunck Optical Flow [4]
     void Coarse_Optical_Flow_TV(in float2 TexCoord, in float Level, in float4 UV, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 6e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 SD = tex2Dlod(Sample_Common_1_C, float4(TexCoord, 0.0, Level + 0.5)).xy;
@@ -435,7 +511,7 @@ namespace Motion_Blur
 
     void Gradient(in float4x2 Samples, out float Gradient)
     {
-        // 2x2 Robert's cross
+        // 2x2 Robert's cross [5]
         // [0] [2]
         // [1] [3]
         float4 SqGradientUV = 0.0;
@@ -464,8 +540,7 @@ namespace Motion_Blur
 
     void Process_Gradients(in float2 SampleUV[9], inout float4 AreaGrad, inout float4 UVGradient)
     {
-        // Center smoothness gradient using Prewitt compass
-        // https://homepages.inf.ed.ac.uk/rbf/HIPR2/prewitt.htm
+        // Calculate center gradient using Prewitt compass operator [6]
         // 0.xy           | 0.zw           | 1.xy           | 1.zw           | 2.xy           | 2.zw           | 3.xy           | 3.zw
         // .......................................................................................................................................
         // -1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 -1.0 | +1.0 -1.0 -1.0 | -1.0 -1.0 -1.0 | -1.0 -1.0 +1.0 |
@@ -508,25 +583,20 @@ namespace Motion_Blur
         Color = (SampleNW + SampleNE + SampleSW + SampleSE) * 0.25;
     }
 
+    // Calculate following levels of Horn-Schunck Optical Flow [4]
     void Optical_Flow_TV(in sampler2D SourceUV, in float4 TexCoords[3], in float Level, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 6e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 SD = tex2Dlod(Sample_Common_1_C, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
         float TD = tex2Dlod(Shared_Resources_Motion_Blur::Sample_Common_1_B, float4(TexCoords[1].xz, 0.0, Level + 0.5)).x;
 
         // Optical flow calculation
-
-        // <Ru, Rv, Gu, Gv>
         float2 SampleUV[9];
-
-        // [0] = Red, [1] = Green
         float4 AreaGrad;
         float4 UVGradient;
-
-        // <Ru, Rv, Gu, Gv>
         float2 AreaAvg[4];
         float4 CenterAverage;
         float4 UVAverage;
@@ -599,7 +669,7 @@ namespace Motion_Blur
     LEVEL_PS(Level_5_PS, Shared_Resources_Motion_Blur::Sample_Common_6, 4.0)
     LEVEL_PS(Level_4_PS, Shared_Resources_Motion_Blur::Sample_Common_5, 3.0)
     LEVEL_PS(Level_3_PS, Shared_Resources_Motion_Blur::Sample_Common_4, 2.0)
-    LEVEL_PS(Level_2_PS, Shared_Resources_Motion_Blur::Sample_Common_3, 1.0)
+    LEVEL_PS(Level_2_PS, Shared_Resources_Motion_Blur::Sample_Common_3_A, 1.0)
 
     void Level_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[3] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
@@ -608,16 +678,20 @@ namespace Motion_Blur
         OutputColor0.ba = float2(0.0, _BlendFactor);
     }
 
-    void Post_Blur_0_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0, out float4 OutputColor1 : SV_TARGET1)
+    void Copy_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
+    {
+        OutputColor0 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoord);
+    }
+
+    void Post_Blur_0_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
         Gaussian_Blur(Sample_Optical_Flow, TexCoords, false, OutputColor0);
         OutputColor0.a = 1.0;
-        OutputColor1 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].xy);
     }
 
     void Post_Blur_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
-        Gaussian_Blur(Shared_Resources_Motion_Blur::Sample_Common_1_B, TexCoords, true, OutputColor0);
+        Gaussian_Blur(Shared_Resources_Motion_Blur::Sample_Common_3_B, TexCoords, true, OutputColor0);
         OutputColor0.a = 1.0;
     }
 
@@ -630,7 +704,7 @@ namespace Motion_Blur
         float FrameRate = 1e+3 / _FrameTime;
         float FrameTimeRatio = _TargetFrameRate / FrameRate;
 
-        float2 Velocity = tex2Dlod(Shared_Resources_Motion_Blur::Sample_Common_1_A, float4(TexCoord, 0.0, _MipBias)).xy;
+        float2 Velocity = tex2Dlod(Shared_Resources_Motion_Blur::Sample_Common_3_A, float4(TexCoord, 0.0, _MipBias)).xy;
 
         float2 ScaledVelocity = (Velocity / BUFFER_SIZE_1) * _Scale;
         ScaledVelocity = (_FrameRateScaling) ?  ScaledVelocity / FrameTimeRatio : ScaledVelocity;
@@ -678,13 +752,14 @@ namespace Motion_Blur
 
         // Calculate spatial and temporal derivative pyramid
         PASS(Basic_VS, Derivatives_Z_PS, Shared_Resources_Motion_Blur::Render_Common_1_B)
+        // NOTE: Do not write to "Render_Common_1_A" until after we copy it to "Render_Common_1_C" to use for the next frame
         PASS(Derivatives_VS, Derivatives_XY_PS, Render_Common_1_C)
 
         // Bilinear Optical Flow
         PASS(Basic_VS, Level_6_PS, Shared_Resources_Motion_Blur::Render_Common_6)
         PASS(Sample_3x3_6_VS, Level_5_PS, Shared_Resources_Motion_Blur::Render_Common_5)
         PASS(Sample_3x3_5_VS, Level_4_PS, Shared_Resources_Motion_Blur::Render_Common_4)
-        PASS(Sample_3x3_4_VS, Level_3_PS, Shared_Resources_Motion_Blur::Render_Common_3)
+        PASS(Sample_3x3_4_VS, Level_3_PS, Shared_Resources_Motion_Blur::Render_Common_3_A)
         PASS(Sample_3x3_3_VS, Level_2_PS, Shared_Resources_Motion_Blur::Render_Common_2)
 
         pass
@@ -699,24 +774,14 @@ namespace Motion_Blur
             DestBlend = SRCALPHA;
         }
 
-        // Gaussian blur
-        pass // Do gaussian blur 0 and copy current convolved frame for next frame
-        {
-            VertexShader = Blur_0_VS;
-            PixelShader = Post_Blur_0_PS;
-            RenderTarget0 = Shared_Resources_Motion_Blur::Render_Common_1_B;
-            RenderTarget1 = Render_Common_1_C;
-        }
+        // Copy current convolved frame for next frame
+        PASS(Basic_VS, Copy_PS, Render_Common_1_C)
 
-        pass
-        {
-            VertexShader = Blur_1_VS;
-            PixelShader = Post_Blur_1_PS;
-            RenderTarget0 = Shared_Resources_Motion_Blur::Render_Common_1_A;
-        }
+        // Gaussian blur
+        PASS(Blur_0_P_VS, Post_Blur_0_PS, Shared_Resources_Motion_Blur::Render_Common_3_B)
+        PASS(Blur_1_P_VS, Post_Blur_1_PS, Shared_Resources_Motion_Blur::Render_Common_3_A)
 
         // Motion blur
-
         pass
         {
             VertexShader = Basic_VS;

--- a/shaders/cMotionBlur.fx
+++ b/shaders/cMotionBlur.fx
@@ -73,32 +73,28 @@
 
 namespace Shared_Resources_Motion_Blur
 {
-    // Store convoluted normalized frame 1 and 3
-
     TEXTURE(Render_Common_0, int2(BUFFER_WIDTH >> 1, BUFFER_HEIGHT >> 1), RG16F, 4)
     SAMPLER(Sample_Common_0, Render_Common_0)
-
-    // Normalized, prefiltered frames for processing
 
     TEXTURE(Render_Common_1_A, BUFFER_SIZE_1, RG16F, 9)
     SAMPLER(Sample_Common_1_A, Render_Common_1_A)
 
-    TEXTURE(Render_Common_1_B, BUFFER_SIZE_1, RGBA16F, 9)
+    TEXTURE(Render_Common_1_B, BUFFER_SIZE_1, RG16F, 9)
     SAMPLER(Sample_Common_1_B, Render_Common_1_B)
 
-    TEXTURE(Render_Common_2, BUFFER_SIZE_2, RGBA16F, 1)
+    TEXTURE(Render_Common_2, BUFFER_SIZE_2, RG16F, 1)
     SAMPLER(Sample_Common_2, Render_Common_2)
 
-    TEXTURE(Render_Common_3, BUFFER_SIZE_3, RGBA16F, 1)
+    TEXTURE(Render_Common_3, BUFFER_SIZE_3, RG16F, 1)
     SAMPLER(Sample_Common_3, Render_Common_3)
 
-    TEXTURE(Render_Common_4, BUFFER_SIZE_4, RGBA16F, 1)
+    TEXTURE(Render_Common_4, BUFFER_SIZE_4, RG16F, 1)
     SAMPLER(Sample_Common_4, Render_Common_4)
 
-    TEXTURE(Render_Common_5, BUFFER_SIZE_5, RGBA16F, 1)
+    TEXTURE(Render_Common_5, BUFFER_SIZE_5, RG16F, 1)
     SAMPLER(Sample_Common_5, Render_Common_5)
 
-    TEXTURE(Render_Common_6, BUFFER_SIZE_6, RGBA16F, 1)
+    TEXTURE(Render_Common_6, BUFFER_SIZE_6, RG16F, 1)
     SAMPLER(Sample_Common_6, Render_Common_6)
 }
 
@@ -120,7 +116,7 @@ namespace Motion_Blur
     OPTION(float, _BlendFactor, "slider", "Optical flow", "Temporal blending factor", 0.0, 0.9, 0.1)
 
     OPTION(bool, _NormalMode, "radio", "Main", "Estimate normals", 0.0, 1.0, false)
-    OPTION(float, _Scale, "slider", "Main", "Blur scale", 0.0, 1.0, 0.5)
+    OPTION(float, _Scale, "slider", "Main", "Blur scale", 0.0, 2.0, 1.5)
 
     OPTION(bool, _FrameRateScaling, "radio", "Other", "Enable frame-rate scaling", 0.0, 1.0, false)
     OPTION(float, _TargetFrameRate, "drag", "Other", "Target frame-rate", 0.0, 144.0, 60.0)
@@ -360,7 +356,7 @@ namespace Motion_Blur
         Gaussian_Blur(Shared_Resources_Motion_Blur::Sample_Common_1_B, TexCoords, true, OutputColor0);
     }
 
-    void Derivatives_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
+    void Derivatives_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
     {
         // Bilinear 5x5 Sobel by CeeJayDK
         //   B1 B2
@@ -377,8 +373,10 @@ namespace Motion_Blur
         float2 C1 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].yz).xy * 4.0; // <+0.5, -1.5>
 
         OutputColor0 = 0.0;
-        OutputColor0.xz = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
-        OutputColor0.yw = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
+        float2 Ix = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
+        float2 Iy = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
+        OutputColor0.x = dot(Ix, 1.0);
+        OutputColor0.y = dot(Iy, 1.0);
     }
 
     /*
@@ -397,41 +395,41 @@ namespace Motion_Blur
 
     #define COARSEST_LEVEL 5
 
-    void Coarse_Optical_Flow_TV(in float2 TexCoord, in float Level, in float4 UV, out float4 OpticalFlow)
+    void Coarse_Optical_Flow_TV(in float2 TexCoord, in float Level, in float4 UV, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 1e-3) / exp2(COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 Current = tex2Dlod(Shared_Resources_Motion_Blur::Sample_Common_1_A, float4(TexCoord, 0.0, Level + 0.5)).xy;
         float2 Previous = tex2Dlod(Sample_Common_1_P, float4(TexCoord, 0.0, Level + 0.5)).xy;
 
         // <Rx, Gx, Ry, Gy>
-        float4 SD = tex2Dlod(Shared_Resources_Motion_Blur::Sample_Common_1_B, float4(TexCoord, 0.0, Level + 0.5));
+        float2 SD = tex2Dlod(Shared_Resources_Motion_Blur::Sample_Common_1_B, float4(TexCoord, 0.0, Level + 0.5)).xy;
 
         // <Rz, Gz>
-        float2 TD = Current - Previous;
+        float TD = dot(Current - Previous, 1.0);
 
-        float2 C = 0.0;
-        float4 Aii = 0.0;
-        float2 Aij = 0.0;
-        float4 Bi = 0.0;
+        float C = 0.0;
+        float2 Aii = 0.0;
+        float Aij = 0.0;
+        float2 Bi = 0.0;
 
         // Calculate constancy assumption nonlinearity
-        C = rsqrt((TD.rg * TD.rg) + FP16_MINIMUM);
+        C = rsqrt((TD * TD) + FP16_MINIMUM);
 
         // Build linear equation
         // [Aii Aij] [X] = [Bi]
         // [Aij Aii] [Y] = [Bi]
-        Aii = 1.0 / (C.rrgg * (SD.xyzw * SD.xyzw) + Alpha);
-        Aij = C.rg * (SD.xz * SD.yw);
-        Bi = C.rrgg * (SD.xyzw * TD.rrgg);
+        Aii = 1.0 / (C * (SD.xy * SD.xy) + Alpha);
+        Aij = C * (SD.x * SD.y);
+        Bi = C * (SD.xy * TD);
 
         // Solve linear equation for [U, V]
         // [Ix^2+A IxIy] [U] = -[IxIt]
         // [IxIy Iy^2+A] [V] = -[IyIt]
-        OpticalFlow.xz = Aii.xz * ((Alpha * UV.xz) - (Aij.rg * UV.yw) - Bi.xz);
-        OpticalFlow.yw = Aii.yw * ((Alpha * UV.yw) - (Aij.rg * OpticalFlow.xz) - Bi.yw);
+        OpticalFlow.x = Aii.x * ((Alpha * UV.x) - (Aij * UV.y) - Bi.x);
+        OpticalFlow.y = Aii.y * ((Alpha * UV.y) - (Aij * OpticalFlow.x) - Bi.y);
     }
 
     void Gradient(in float4x2 Samples, out float Gradient)
@@ -504,39 +502,37 @@ namespace Motion_Blur
         UVGradient = 0.5 * (CenterGradient + AreaGrad);
     }
 
-    void Area_Average(in float4 SampleNW, in float4 SampleNE, in float4 SampleSW, in float4 SampleSE, out float4 Color)
+    void Area_Average(in float2 SampleNW, in float2 SampleNE, in float2 SampleSW, in float2 SampleSE, out float2 Color)
     {
         Color = (SampleNW + SampleNE + SampleSW + SampleSE) * 0.25;
     }
 
-    void Optical_Flow_TV(in sampler2D SourceUV, in float4 TexCoords[3], in float Level, out float4 OpticalFlow)
+    void Optical_Flow_TV(in sampler2D SourceUV, in float4 TexCoords[3], in float Level, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 1e-3) / exp2(COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 Current = tex2Dlod(Shared_Resources_Motion_Blur::Sample_Common_1_A, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
         float2 Previous = tex2Dlod(Sample_Common_1_P, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
 
         // <Rx, Ry, Gx, Gy>
-        float4 SD = tex2Dlod(Shared_Resources_Motion_Blur::Sample_Common_1_B, float4(TexCoords[1].xz, 0.0, Level + 0.5));
+        float2 SD = tex2Dlod(Shared_Resources_Motion_Blur::Sample_Common_1_B, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
 
         // <Rz, Gz>
-        float2 TD = Current - Previous;
+        float TD = dot(Current - Previous, 1.0);
 
         // Optical flow calculation
 
         // <Ru, Rv, Gu, Gv>
-        float4 SampleUV[9];
-        float2 SampleUVR[9];
-        float2 SampleUVG[9];
+        float2 SampleUV[9];
 
         // [0] = Red, [1] = Green
-        float4 AreaGrad[2];
-        float4 UVGradient[2];
+        float4 AreaGrad;
+        float4 UVGradient;
 
         // <Ru, Rv, Gu, Gv>
-        float4 AreaAvg[4];
+        float2 AreaAvg[4];
         float4 CenterAverage;
         float4 UVAverage;
 
@@ -544,29 +540,20 @@ namespace Motion_Blur
         // 0 3 6
         // 1 4 7
         // 2 5 8
-        SampleUV[0] = tex2D(SourceUV, TexCoords[0].xy);
-        SampleUV[1] = tex2D(SourceUV, TexCoords[0].xz);
-        SampleUV[2] = tex2D(SourceUV, TexCoords[0].xw);
-        SampleUV[3] = tex2D(SourceUV, TexCoords[1].xy);
-        SampleUV[4] = tex2D(SourceUV, TexCoords[1].xz);
-        SampleUV[5] = tex2D(SourceUV, TexCoords[1].xw);
-        SampleUV[6] = tex2D(SourceUV, TexCoords[2].xy);
-        SampleUV[7] = tex2D(SourceUV, TexCoords[2].xz);
-        SampleUV[8] = tex2D(SourceUV, TexCoords[2].xw);
-
-        [unroll]for(int i = 0; i < 9; i++)
-        {
-            SampleUVR[i] = SampleUV[i].xy;
-            SampleUVG[i] = SampleUV[i].zw;
-        }
+        SampleUV[0] = tex2D(SourceUV, TexCoords[0].xy).xy;
+        SampleUV[1] = tex2D(SourceUV, TexCoords[0].xz).xy;
+        SampleUV[2] = tex2D(SourceUV, TexCoords[0].xw).xy;
+        SampleUV[3] = tex2D(SourceUV, TexCoords[1].xy).xy;
+        SampleUV[4] = tex2D(SourceUV, TexCoords[1].xz).xy;
+        SampleUV[5] = tex2D(SourceUV, TexCoords[1].xw).xy;
+        SampleUV[6] = tex2D(SourceUV, TexCoords[2].xy).xy;
+        SampleUV[7] = tex2D(SourceUV, TexCoords[2].xz).xy;
+        SampleUV[8] = tex2D(SourceUV, TexCoords[2].xw).xy;
 
         // Process area gradients in each patch, per plane
-
-        Process_Gradients(SampleUVR, AreaGrad[0], UVGradient[0]);
-        Process_Gradients(SampleUVG, AreaGrad[1], UVGradient[1]);
+        Process_Gradients(SampleUV, AreaGrad, UVGradient);
 
         // Calculate area + center averages of estimated vectors
-
         Area_Average(SampleUV[0], SampleUV[3], SampleUV[1], SampleUV[4], AreaAvg[0]);
         Area_Average(SampleUV[3], SampleUV[6], SampleUV[4], SampleUV[7], AreaAvg[1]);
         Area_Average(SampleUV[1], SampleUV[4], SampleUV[2], SampleUV[5], AreaAvg[2]);
@@ -577,42 +564,39 @@ namespace Motion_Blur
         CenterAverage += (SampleUV[4] * 4.0);
         CenterAverage = CenterAverage / 16.0;
 
-        float2 C = 0.0;
-        float4 Aii = 0.0;
-        float2 Aij = 0.0;
-        float4 Bi = 0.0;
+        float C = 0.0;
+        float2 Aii = 0.0;
+        float Aij = 0.0;
+        float2 Bi = 0.0;
 
         // Calculate constancy assumption nonlinearity
         // Dot-product increases when the current gradient + previous estimation are parallel
         // IxU + IyV = -It -> IxU + IyV + It = 0.0
-        C.r = dot(SD.xy, CenterAverage.xy) + TD.r;
-        C.g = dot(SD.zw, CenterAverage.zw) + TD.g;
-        C.rg = rsqrt((C.rg * C.rg) + FP16_MINIMUM);
+        C = dot(SD.xy, CenterAverage.xy) + TD;
+        C = rsqrt((C * C) + FP16_MINIMUM);
 
         // Build linear equation
         // [Aii Aij] [X] = [Bi]
         // [Aij Aii] [Y] = [Bi]
-        Aii.xy = 1.0 / (dot(UVGradient[0], 1.0) * Alpha + (C.rr * (SD.xy * SD.xy)));
-        Aii.zw = 1.0 / (dot(UVGradient[1], 1.0) * Alpha + (C.gg * (SD.zw * SD.zw)));
-        Aij.xy = C.rg * (SD.xz * SD.yw);
-        Bi = C.rrgg * (SD.xyzw * TD.rrgg);
+        Aii = 1.0 / (dot(UVGradient, 1.0) * Alpha + (C * (SD.xy * SD.xy)));
+        Aij = C * (SD.x * SD.y);
+        Bi = C * (SD.xy * TD);
 
         // Solve linear equation for [U, V]
         // [Ix^2+A IxIy] [U] = -[IxIt]
         // [IxIy Iy^2+A] [V] = -[IyIt]
-        UVAverage.xy = (AreaGrad[0].xx * AreaAvg[0].xy) + (AreaGrad[0].yy * AreaAvg[1].xy) + (AreaGrad[0].zz * AreaAvg[2].xy) + (AreaGrad[0].ww * AreaAvg[3].xy);
-        UVAverage.zw = (AreaGrad[1].xx * AreaAvg[0].zw) + (AreaGrad[1].yy * AreaAvg[1].zw) + (AreaGrad[1].zz * AreaAvg[2].zw) + (AreaGrad[1].ww * AreaAvg[3].zw);
-        OpticalFlow.xz = Aii.xz * ((Alpha * UVAverage.xz) - (Aij.rg * CenterAverage.yw) - Bi.xz);
-        OpticalFlow.yw = Aii.yw * ((Alpha * UVAverage.yw) - (Aij.rg * OpticalFlow.xz) - Bi.yw);
+        UVAverage.xy = (AreaGrad.xx * AreaAvg[0]) + (AreaGrad.yy * AreaAvg[1]) + (AreaGrad.zz * AreaAvg[2]) + (AreaGrad.ww * AreaAvg[3]);
+        OpticalFlow.x = Aii.x * ((Alpha * UVAverage.x) - (Aij * CenterAverage.y) - Bi.x);
+        OpticalFlow.y = Aii.y * ((Alpha * UVAverage.y) - (Aij * OpticalFlow.x) - Bi.y);
     }
 
     #define LEVEL_PS(NAME, SAMPLER, LEVEL)                                                                             \
-        void NAME(in float4 Position : SV_POSITION, in float4 TexCoords[3] : TEXCOORD0, out float4 Color : SV_TARGET0) \
+        void NAME(in float4 Position : SV_POSITION, in float4 TexCoords[3] : TEXCOORD0, out float2 Color : SV_TARGET0) \
         {                                                                                                              \
             Optical_Flow_TV(SAMPLER, TexCoords, LEVEL, Color);                                                         \
         }
 
-    void Level_6_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float4 Color : SV_TARGET0)
+    void Level_6_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float2 Color : SV_TARGET0)
     {
         Coarse_Optical_Flow_TV(TexCoord, 5.0, 0.0, Color);
     }
@@ -624,9 +608,8 @@ namespace Motion_Blur
 
     void Level_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[3] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
-        float4 OpticalFlow = 0.0;
-        Optical_Flow_TV(Shared_Resources_Motion_Blur::Sample_Common_2, TexCoords, 0.0, OpticalFlow);
-        OutputColor0.rg = OpticalFlow.xy + OpticalFlow.zw;
+        OutputColor0 = 0.0;
+        Optical_Flow_TV(Shared_Resources_Motion_Blur::Sample_Common_2, TexCoords, 0.0, OutputColor0.xy);
         OutputColor0.ba = float2(0.0, _BlendFactor);
     }
 

--- a/shaders/cMotionBlur.fx
+++ b/shaders/cMotionBlur.fx
@@ -116,7 +116,7 @@ namespace Motion_Blur
     OPTION(float, _BlendFactor, "slider", "Optical flow", "Temporal blending factor", 0.0, 0.9, 0.1)
 
     OPTION(bool, _NormalMode, "radio", "Main", "Estimate normals", 0.0, 1.0, false)
-    OPTION(float, _Scale, "slider", "Main", "Blur scale", 0.0, 2.0, 1.5)
+    OPTION(float, _Scale, "slider", "Main", "Blur scale", 0.0, 2.0, 1.0)
 
     OPTION(bool, _FrameRateScaling, "radio", "Other", "Enable frame-rate scaling", 0.0, 1.0, false)
     OPTION(float, _TargetFrameRate, "drag", "Other", "Target frame-rate", 0.0, 144.0, 60.0)

--- a/shaders/cMotionBlur.fx
+++ b/shaders/cMotionBlur.fx
@@ -317,7 +317,7 @@ namespace Motion_Blur
         int CoordIndex = 1;
         int WeightIndex = 1;
 
-        while(CoordIndex < 4) // for(int i = 1; i < 4; i++)
+        while(CoordIndex < 4)
         {
             if(!Alt)
             {

--- a/shaders/cMotionBlur.fx
+++ b/shaders/cMotionBlur.fx
@@ -482,15 +482,15 @@ namespace Motion_Blur
         // [1] [4] [7]
         // [2] [5] [8]
         float2 Output;
-        Output += (SampleUV[0] * Weights[0][0]);
-        Output += (SampleUV[1] * Weights[0][1]);
-        Output += (SampleUV[2] * Weights[0][2]);
-        Output += (SampleUV[3] * Weights[1][0]);
-        Output += (SampleUV[4] * Weights[1][1]);
-        Output += (SampleUV[5] * Weights[1][2]);
-        Output += (SampleUV[6] * Weights[2][0]);
-        Output += (SampleUV[7] * Weights[2][1]);
-        Output += (SampleUV[8] * Weights[2][2]);
+        Output += (SampleUV[0] * Weights._11);
+        Output += (SampleUV[1] * Weights._12);
+        Output += (SampleUV[2] * Weights._13);
+        Output += (SampleUV[3] * Weights._21);
+        Output += (SampleUV[4] * Weights._22);
+        Output += (SampleUV[5] * Weights._23);
+        Output += (SampleUV[6] * Weights._31);
+        Output += (SampleUV[7] * Weights._32);
+        Output += (SampleUV[8] * Weights._33);
         return Output;
     }
 
@@ -504,13 +504,13 @@ namespace Motion_Blur
         // -1.0 +1.0 +1.0 | -1.0 -1.0 +1.0 | -1.0 -1.0 -1.0 | +1.0 -1.0 -1.0 | +1.0 +1.0 -1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 |
 
         float4 PrewittUV[4];
-        PrewittUV[0].xy = Prewitt(SampleUV, float3x3(-1.0, -1.0, -1.0, +1.0, -2.0, +1.0, +1.0, +1.0, +1.0));
-        PrewittUV[0].zw = Prewitt(SampleUV, float3x3(+1.0, -1.0, -1.0, +1.0, -2.0, -1.0, +1.0, +1.0, +1.0));
-        PrewittUV[1].xy = Prewitt(SampleUV, float3x3(+1.0, +1.0, -1.0, +1.0, -2.0, -1.0, +1.0, +1.0, -1.0));
+        PrewittUV[0].xy = Prewitt(SampleUV, float3x3(-1.0, +1.0, +1.0, -1.0, -2.0, +1.0, -1.0, +1.0, +1.0));
+        PrewittUV[0].zw = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, -1.0, -2.0, +1.0, -1.0, -1.0, +1.0));
+        PrewittUV[1].xy = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, +1.0, -2.0, +1.0, -1.0, -1.0, -1.0));
         PrewittUV[1].zw = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, +1.0, -2.0, -1.0, +1.0, -1.0, -1.0));
-        PrewittUV[2].xy = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, +1.0, -2.0, +1.0, -1.0, -1.0, -1.0));
-        PrewittUV[2].zw = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, -1.0, -2.0, +1.0, -1.0, -1.0, +1.0));
-        PrewittUV[3].xy = Prewitt(SampleUV, float3x3(-1.0, +1.0, +1.0, -1.0, -2.0, +1.0, -1.0, +1.0, +1.0));
+        PrewittUV[2].xy = Prewitt(SampleUV, float3x3(+1.0, +1.0, -1.0, +1.0, -2.0, -1.0, +1.0, +1.0, -1.0));
+        PrewittUV[2].zw = Prewitt(SampleUV, float3x3(+1.0, -1.0, -1.0, +1.0, -2.0, -1.0, +1.0, +1.0, +1.0));
+        PrewittUV[3].xy = Prewitt(SampleUV, float3x3(-1.0, -1.0, -1.0, +1.0, -2.0, +1.0, +1.0, +1.0, +1.0));
         PrewittUV[3].zw = Prewitt(SampleUV, float3x3(-1.0, -1.0, +1.0, -1.0, -2.0, +1.0, +1.0, +1.0, +1.0));
 
         float2 MaxGradient[3];

--- a/shaders/cMotionBlur.fx
+++ b/shaders/cMotionBlur.fx
@@ -165,41 +165,37 @@ namespace Motion_Blur
         Position = float4(TexCoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
     }
 
-    static const float2 BlurOffsets[8] =
+    static const float4 BlurOffsets[4] =
     {
-        float2(0.0, 0.0),
-        float2(0.0, 1.4850045),
-        float2(0.0, 3.4650571),
-        float2(0.0, 5.445221),
-        float2(0.0, 7.4255576),
-        float2(0.0, 9.406127),
-        float2(0.0, 11.386987),
-        float2(0.0, 13.368189)
+        float4(0.0, 0.0, 0.0, 0.0),
+        float4(0.0, 1.490652, 3.4781995, 5.465774),
+        float4(0.0, 7.45339, 9.441065, 11.42881),
+        float4(0.0, 13.416645, 15.404578, 17.392626)
     };
 
-    void Blur_0_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[8] : TEXCOORD0)
+    void Blur_0_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[7] : TEXCOORD0)
     {
         float2 CoordVS = 0.0;
         Basic_VS(ID, Position, CoordVS);
         TexCoords[0] = CoordVS.xyxy;
 
-        for(int i = 1; i < 8; i++)
+        for(int i = 1; i < 4; i++)
         {
-            TexCoords[i].xy = CoordVS.xy - (BlurOffsets[i].yx / BUFFER_SIZE_1);
-            TexCoords[i].zw = CoordVS.xy + (BlurOffsets[i].yx / BUFFER_SIZE_1);
+            TexCoords[i] = CoordVS.xyyy + (BlurOffsets[i].xyzw / BUFFER_SIZE_1.xyyy);
+            TexCoords[i + 3] = CoordVS.xyyy - (BlurOffsets[i].xyzw / BUFFER_SIZE_1.xyyy);
         }
     }
 
-    void Blur_1_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[8] : TEXCOORD0)
+    void Blur_1_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[7] : TEXCOORD0)
     {
         float2 CoordVS = 0.0;
         Basic_VS(ID, Position, CoordVS);
         TexCoords[0] = CoordVS.xyxy;
 
-        for(int i = 1; i < 8; i++)
+        for(int i = 1; i < 4; i++)
         {
-            TexCoords[i].xy = CoordVS.xy - (BlurOffsets[i].xy / BUFFER_SIZE_1);
-            TexCoords[i].zw = CoordVS.xy + (BlurOffsets[i].xy / BUFFER_SIZE_1);
+            TexCoords[i] = CoordVS.xxxy + (BlurOffsets[i].yzwx / BUFFER_SIZE_1.xxxy);
+            TexCoords[i + 3] = CoordVS.xxxy - (BlurOffsets[i].yzwx / BUFFER_SIZE_1.xxxy);
         }
     }
 
@@ -299,41 +295,69 @@ namespace Motion_Blur
         OutputColor0 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_0, TexCoord);
     }
 
-    static const float BlurWeights[8] =
+    static const float BlurWeights[10] =
     {
-        0.079788454,
-        0.15186256,
-        0.12458323,
-        0.08723135,
-        0.05212966,
-        0.026588224,
-        0.011573823,
-        0.0042996835
+        0.06299088,
+        0.122137636,
+        0.10790718,
+        0.08633988,
+        0.062565096,
+        0.04105926,
+        0.024403222,
+        0.013135255,
+        0.006402994,
+        0.002826693
     };
 
-    void Gaussian_Blur(in sampler2D Source, in float4 TexCoords[8], out float4 OutputColor0)
+    void Gaussian_Blur(in sampler2D Source, in float4 TexCoords[7], bool Alt, out float4 OutputColor0)
     {
         float TotalWeights = BlurWeights[0];
         OutputColor0 = (tex2D(Source, TexCoords[0].xy) * BlurWeights[0]);
 
-        for(int i = 1; i < 8; i++)
+        int CoordIndex = 1;
+        int WeightIndex = 1;
+
+        while(CoordIndex < 4) // for(int i = 1; i < 4; i++)
         {
-            OutputColor0 += (tex2D(Source, TexCoords[i].xy) * BlurWeights[i]);
-            OutputColor0 += (tex2D(Source, TexCoords[i].zw) * BlurWeights[i]);
+            if(!Alt)
+            {
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex].xy) * BlurWeights[WeightIndex + 0]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex].xz) * BlurWeights[WeightIndex + 1]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex].xw) * BlurWeights[WeightIndex + 2]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex + 3].xy) * BlurWeights[WeightIndex + 0]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex + 3].xz) * BlurWeights[WeightIndex + 1]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex + 3].xw) * BlurWeights[WeightIndex + 2]);
+            }
+            else
+            {
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex].xw) * BlurWeights[WeightIndex + 0]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex].yw) * BlurWeights[WeightIndex + 1]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex].zw) * BlurWeights[WeightIndex + 2]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex + 3].xw) * BlurWeights[WeightIndex + 0]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex + 3].yw) * BlurWeights[WeightIndex + 1]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex + 3].zw) * BlurWeights[WeightIndex + 2]);
+            }
+
+            CoordIndex = CoordIndex + 1;
+            WeightIndex = WeightIndex + 3;
+        }
+
+        for(int i = 1; i < 10; i++)
+        {
             TotalWeights += (BlurWeights[i] * 2.0);
         }
 
-        OutputColor0  = OutputColor0 / TotalWeights;
+        OutputColor0 = OutputColor0 / TotalWeights;
     }
 
-    void Pre_Blur_0_PS(in float4 Position : SV_POSITION, in float4 TexCoords[8] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
+    void Pre_Blur_0_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
-        Gaussian_Blur(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords, OutputColor0);
+        Gaussian_Blur(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords, false, OutputColor0);
     }
 
-    void Pre_Blur_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[8] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
+    void Pre_Blur_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
-        Gaussian_Blur(Shared_Resources_Motion_Blur::Sample_Common_1_B, TexCoords, OutputColor0);
+        Gaussian_Blur(Shared_Resources_Motion_Blur::Sample_Common_1_B, TexCoords, true, OutputColor0);
     }
 
     void Derivatives_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
@@ -606,16 +630,16 @@ namespace Motion_Blur
         OutputColor0.ba = float2(0.0, _BlendFactor);
     }
 
-    void Post_Blur_0_PS(in float4 Position : SV_POSITION, in float4 TexCoords[8] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0, out float4 OutputColor1 : SV_TARGET1)
+    void Post_Blur_0_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0, out float4 OutputColor1 : SV_TARGET1)
     {
-        Gaussian_Blur(Sample_Optical_Flow, TexCoords, OutputColor0);
+        Gaussian_Blur(Sample_Optical_Flow, TexCoords, false, OutputColor0);
         OutputColor0.a = 1.0;
         OutputColor1 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].xy);
     }
 
-    void Post_Blur_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[8] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
+    void Post_Blur_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
-        Gaussian_Blur(Shared_Resources_Motion_Blur::Sample_Common_1_B, TexCoords, OutputColor0);
+        Gaussian_Blur(Shared_Resources_Motion_Blur::Sample_Common_1_B, TexCoords, true, OutputColor0);
         OutputColor0.a = 1.0;
     }
 

--- a/shaders/cMotionBlur.fx
+++ b/shaders/cMotionBlur.fx
@@ -252,23 +252,7 @@ namespace Motion_Blur
         [2] Normal encoding
             https://knarkowicz.wordpress.com/2014/04/16/octahedron-normal-vector-encoding/
 
-        [3] Polar-coordinate diagram
-            https://opg.optica.org/josaa/fulltext.cfm?uri=josaa-37-11-1721&id=440913
-
-                @article{buzzelli2020arc,
-                    title = {ARC: Angle-Retaining Chromaticity diagram for color constancy error analysis},
-                    author = {Marco Buzzelli and Simone Bianco and Raimondo Schettini},
-                    journal = {J. Opt. Soc. Am. A},
-                    number = {11},
-                    pages = {1721--1730},
-                    publisher = {OSA},
-                    volume = {37},
-                    month = {Nov},
-                    year = {2020},
-                    doi = {10.1364/JOSAA.398692}
-                }
-
-        [4] Horn-Schunck Optical Flow
+        [3] Horn-Schunck Optical Flow
             https://github.com/Dtananaev/cv_opticalFlow
 
                 Copyright (c) 2014-2015, Denis Tananaev All rights reserved.
@@ -288,10 +272,10 @@ namespace Motion_Blur
                 STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
                 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-        [5] Robert's cross operator
+        [4] Robert's cross operator
             https://homepages.inf.ed.ac.uk/rbf/HIPR2/roberts.htm
 
-        [6] Prewitt compass operator
+        [5] Prewitt compass operator
             https://homepages.inf.ed.ac.uk/rbf/HIPR2/prewitt.htm
     */
 
@@ -335,6 +319,7 @@ namespace Motion_Blur
 
     void Normalize_Frame_PS(in float4 Position : SV_POSITION, float2 TexCoord : TEXCOORD, out float2 Color : SV_TARGET0)
     {
+        Color = 0.0;
         if(_NormalMode)
         {
             Color.xy = Encode(Get_Screen_Space_Normal(TexCoord));
@@ -342,10 +327,7 @@ namespace Motion_Blur
         else
         {
             float4 Frame = max(tex2D(Sample_Color, TexCoord), exp2(-10.0));
-            // Convert RGB into ARC's polar coordinates [3]
-            // Append "FP16_MINIMUM" to avoid dividing by zero
-            Color.x = saturate(acos(dot(Frame.rgb, 1.0) / (sqrt(3.0) * length(Frame.rgb))));
-            Color.y = atan2(dot(Frame.gb, float2(sqrt(3.0), -sqrt(3.0))), dot(Frame.rgb, float3(2.0, -1.0, -1.0)) + FP16_MINIMUM);
+            Color.xy = saturate(Frame.xy / dot(Frame.xyz, 1.0));
         }
     }
 
@@ -419,20 +401,11 @@ namespace Motion_Blur
         Gaussian_Blur(Shared_Resources_Motion_Blur::Sample_Common_1_B, TexCoords, true, OutputColor0);
     }
 
-    // Turn the packed angle vector into its respective unit vectors
-    float3 HS_Units_2D(sampler2D Source, float2 TexCoord)
-    {
-        float3 Color = tex2D(Source, TexCoord).xyz;
-        sincos(Color.y, Color.z, Color.y);
-        Color.zy = saturate(Color.zy * 0.5 + 0.5);
-        return Color;
-    }
-
     void Derivatives_Z_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
     {
-        float3 Current = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoord);
-        float3 Previous = HS_Units_2D(Sample_Common_1_C, TexCoord);
-        OutputColor0 = dot(Current - Previous, float3(0.95, 0.025, 0.025));
+        float2 Current = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoord).xy;
+        float2 Previous = tex2D(Sample_Common_1_C, TexCoord).xy;
+        OutputColor0 = dot(Current - Previous, 1.0);
     }
 
     void Derivatives_XY_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
@@ -442,29 +415,29 @@ namespace Motion_Blur
         // A0     A1
         // A2     B0
         //   C0 C1
-        float3 A0 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].xw) * 4.0; // <-1.5, +0.5>
-        float3 A1 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].yw) * 4.0; // <+1.5, +0.5>
-        float3 A2 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].xz) * 4.0; // <-1.5, -0.5>
-        float3 B0 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].yz) * 4.0; // <+1.5, -0.5>
-        float3 B1 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].xw) * 4.0; // <-0.5, +1.5>
-        float3 B2 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].yw) * 4.0; // <+0.5, +1.5>
-        float3 C0 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].xz) * 4.0; // <-0.5, -1.5>
-        float3 C1 = HS_Units_2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].yz) * 4.0; // <+0.5, -1.5>
+        float2 A0 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].xw).xy * 4.0; // <-1.5, +0.5>
+        float2 A1 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].yw).xy * 4.0; // <+1.5, +0.5>
+        float2 A2 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].xz).xy * 4.0; // <-1.5, -0.5>
+        float2 B0 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[0].yz).xy * 4.0; // <+1.5, -0.5>
+        float2 B1 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].xw).xy * 4.0; // <-0.5, +1.5>
+        float2 B2 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].yw).xy * 4.0; // <+0.5, +1.5>
+        float2 C0 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].xz).xy * 4.0; // <-0.5, -1.5>
+        float2 C1 = tex2D(Shared_Resources_Motion_Blur::Sample_Common_1_A, TexCoords[1].yz).xy * 4.0; // <+0.5, -1.5>
 
         OutputColor0 = 0.0;
-        float3 Ix = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
-        float3 Iy = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
-        OutputColor0.x = dot(Ix, float3(0.95, 0.025, 0.025));
-        OutputColor0.y = dot(Iy, float3(0.95, 0.025, 0.025));
+        float2 Ix = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
+        float2 Iy = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
+        OutputColor0.x = dot(Ix, 1.0);
+        OutputColor0.y = dot(Iy, 1.0);
     }
 
     #define COARSEST_LEVEL 5
 
-    // Calculate first level of Horn-Schunck Optical Flow [4]
+    // Calculate first level of Horn-Schunck Optical Flow
     void Coarse_Optical_Flow_TV(in float2 TexCoord, in float Level, in float4 UV, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 6e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 1e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 SD = tex2Dlod(Sample_Common_1_C, float4(TexCoord, 0.0, Level + 0.5)).xy;
@@ -494,7 +467,7 @@ namespace Motion_Blur
 
     void Gradient(in float4x2 Samples, out float Gradient)
     {
-        // 2x2 Robert's cross [5]
+        // 2x2 Robert's cross
         // [0] [2]
         // [1] [3]
         float4 SqGradientUV = 0.0;
@@ -523,7 +496,7 @@ namespace Motion_Blur
 
     void Process_Gradients(in float2 SampleUV[9], inout float4 AreaGrad, inout float4 UVGradient)
     {
-        // Calculate center gradient using Prewitt compass operator [6]
+        // Calculate center gradient using Prewitt compass operator
         // 0.xy           | 0.zw           | 1.xy           | 1.zw           | 2.xy           | 2.zw           | 3.xy           | 3.zw
         // .......................................................................................................................................
         // -1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 -1.0 | +1.0 -1.0 -1.0 | -1.0 -1.0 -1.0 | -1.0 -1.0 +1.0 |
@@ -566,11 +539,11 @@ namespace Motion_Blur
         Color = (SampleNW + SampleNE + SampleSW + SampleSE) * 0.25;
     }
 
-    // Calculate following levels of Horn-Schunck Optical Flow [4]
+    // Calculate following levels of Horn-Schunck Optical Flow
     void Optical_Flow_TV(in sampler2D SourceUV, in float4 TexCoords[3], in float Level, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 6e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 1e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 SD = tex2Dlod(Sample_Common_1_C, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;

--- a/shaders/cOpticalFlow.fx
+++ b/shaders/cOpticalFlow.fx
@@ -342,29 +342,7 @@ namespace OpticalFlow
     /*
         [Pixel Shaders]
 
-        [1] Generate normals
-            https://github.com/crosire/reshade-shaders/blob/slim/Shaders/DisplayDepth.fx
-
-        [2] Normal encoding
-            https://knarkowicz.wordpress.com/2014/04/16/octahedron-normal-vector-encoding/
-
-        [3] Polar-coordinate diagram
-            https://opg.optica.org/josaa/fulltext.cfm?uri=josaa-37-11-1721&id=440913
-
-                @article{buzzelli2020arc,
-                    title = {ARC: Angle-Retaining Chromaticity diagram for color constancy error analysis},
-                    author = {Marco Buzzelli and Simone Bianco and Raimondo Schettini},
-                    journal = {J. Opt. Soc. Am. A},
-                    number = {11},
-                    pages = {1721--1730},
-                    publisher = {OSA},
-                    volume = {37},
-                    month = {Nov},
-                    year = {2020},
-                    doi = {10.1364/JOSAA.398692}
-                }
-
-        [4] Horn-Schunck Optical Flow
+        [1] Horn-Schunck Optical Flow
             https://github.com/Dtananaev/cv_opticalFlow
 
                 Copyright (c) 2014-2015, Denis Tananaev All rights reserved.
@@ -384,20 +362,17 @@ namespace OpticalFlow
                 STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
                 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-        [5] Robert's cross operator
+        [2] Robert's cross operator
             https://homepages.inf.ed.ac.uk/rbf/HIPR2/roberts.htm
 
-        [6] Prewitt compass operator
+        [3] Prewitt compass operator
             https://homepages.inf.ed.ac.uk/rbf/HIPR2/prewitt.htm
     */
 
     void Normalize_Frame_PS(in float4 Position : SV_POSITION, float2 TexCoord : TEXCOORD, out float2 Color : SV_TARGET0)
     {
         float4 Frame = max(tex2D(Sample_Color, TexCoord), exp2(-10.0));
-        // Convert RGB into ARC's polar coordinates [3]
-        // Append "FP16_MINIMUM" to avoid dividing by zero
-        Color.x = saturate(acos(dot(Frame.rgb, 1.0) / (sqrt(3.0) * length(Frame.rgb))));
-        Color.y = atan2(dot(Frame.gb, float2(sqrt(3.0), -sqrt(3.0))), dot(Frame.rgb, float3(2.0, -1.0, -1.0)) + FP16_MINIMUM);
+        Color.xy = saturate(Frame.xy / dot(Frame.xyz, 1.0));
     }
 
     void Blit_Frame_PS(in float4 Position : SV_POSITION, float2 TexCoord : TEXCOORD, out float4 OutputColor0 : SV_TARGET0)
@@ -470,20 +445,11 @@ namespace OpticalFlow
         Gaussian_Blur(Shared_Resources_Flow::Sample_Common_1_B, TexCoords, true, OutputColor0);
     }
 
-    // Turn the packed angle vector into its respective unit vectors
-    float3 HS_Units_2D(sampler2D Source, float2 TexCoord)
-    {
-        float3 Color = tex2D(Source, TexCoord).xyz;
-        sincos(Color.y, Color.z, Color.y);
-        Color.zy = saturate(Color.zy * 0.5 + 0.5);
-        return Color;
-    }
-
     void Derivatives_Z_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
     {
-        float3 Current = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoord);
-        float3 Previous = HS_Units_2D(Sample_Common_1_C, TexCoord);
-        OutputColor0 = dot(Current - Previous, float3(0.95, 0.025, 0.025));
+        float2 Current = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoord).xy;
+        float2 Previous = tex2D(Sample_Common_1_C, TexCoord).xy;
+        OutputColor0 = dot(Current - Previous, 1.0);
     }
 
     void Derivatives_XY_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
@@ -493,29 +459,29 @@ namespace OpticalFlow
         // A0     A1
         // A2     B0
         //   C0 C1
-        float3 A0 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].xw) * 4.0; // <-1.5, +0.5>
-        float3 A1 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].yw) * 4.0; // <+1.5, +0.5>
-        float3 A2 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].xz) * 4.0; // <-1.5, -0.5>
-        float3 B0 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].yz) * 4.0; // <+1.5, -0.5>
-        float3 B1 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].xw) * 4.0; // <-0.5, +1.5>
-        float3 B2 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].yw) * 4.0; // <+0.5, +1.5>
-        float3 C0 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].xz) * 4.0; // <-0.5, -1.5>
-        float3 C1 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].yz) * 4.0; // <+0.5, -1.5>
+        float2 A0 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].xw).xy * 4.0; // <-1.5, +0.5>
+        float2 A1 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].yw).xy * 4.0; // <+1.5, +0.5>
+        float2 A2 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].xz).xy * 4.0; // <-1.5, -0.5>
+        float2 B0 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].yz).xy * 4.0; // <+1.5, -0.5>
+        float2 B1 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].xw).xy * 4.0; // <-0.5, +1.5>
+        float2 B2 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].yw).xy * 4.0; // <+0.5, +1.5>
+        float2 C0 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].xz).xy * 4.0; // <-0.5, -1.5>
+        float2 C1 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].yz).xy * 4.0; // <+0.5, -1.5>
 
         OutputColor0 = 0.0;
-        float3 Ix = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
-        float3 Iy = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
-        OutputColor0.x = dot(Ix, float3(0.95, 0.025, 0.025));
-        OutputColor0.y = dot(Iy, float3(0.95, 0.025, 0.025));
+        float2 Ix = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
+        float2 Iy = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
+        OutputColor0.x = dot(Ix, 1.0);
+        OutputColor0.y = dot(Iy, 1.0);
     }
 
     #define COARSEST_LEVEL 5
 
-    // Calculate first level of Horn-Schunck Optical Flow [4]
+    // Calculate first level of Horn-Schunck Optical Flow
     void Coarse_Optical_Flow_TV(in float2 TexCoord, in float Level, in float4 UV, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 6e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 1e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 SD = tex2Dlod(Sample_Common_1_C, float4(TexCoord, 0.0, Level + 0.5)).xy;
@@ -545,7 +511,7 @@ namespace OpticalFlow
 
     void Gradient(in float4x2 Samples, out float Gradient)
     {
-        // 2x2 Robert's cross [5]
+        // 2x2 Robert's cross
         // [0] [2]
         // [1] [3]
         float4 SqGradientUV = 0.0;
@@ -574,7 +540,7 @@ namespace OpticalFlow
 
     void Process_Gradients(in float2 SampleUV[9], inout float4 AreaGrad, inout float4 UVGradient)
     {
-        // Calculate center gradient using Prewitt compass operator [6]
+        // Calculate center gradient using Prewitt compass operator
         // 0.xy           | 0.zw           | 1.xy           | 1.zw           | 2.xy           | 2.zw           | 3.xy           | 3.zw
         // .......................................................................................................................................
         // -1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 -1.0 | +1.0 -1.0 -1.0 | -1.0 -1.0 -1.0 | -1.0 -1.0 +1.0 |
@@ -617,11 +583,11 @@ namespace OpticalFlow
         Color = (SampleNW + SampleNE + SampleSW + SampleSE) * 0.25;
     }
 
-    // Calculate following levels of Horn-Schunck Optical Flow [4]
+    // Calculate following levels of Horn-Schunck Optical Flow
     void Optical_Flow_TV(in sampler2D SourceUV, in float4 TexCoords[3], in float Level, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 6e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 1e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 SD = tex2Dlod(Sample_Common_1_C, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;

--- a/shaders/cOpticalFlow.fx
+++ b/shaders/cOpticalFlow.fx
@@ -341,7 +341,7 @@ namespace OpticalFlow
         int CoordIndex = 1;
         int WeightIndex = 1;
 
-        while(CoordIndex < 4) // for(int i = 1; i < 4; i++)
+        while(CoordIndex < 4)
         {
             if(!Alt)
             {

--- a/shaders/cOpticalFlow.fx
+++ b/shaders/cOpticalFlow.fx
@@ -80,8 +80,11 @@ namespace Shared_Resources_Flow
     TEXTURE(Render_Common_1_B, BUFFER_SIZE_1, RG16F, 9)
     SAMPLER(Sample_Common_1_B, Render_Common_1_B)
 
-    TEXTURE(Render_Common_2, BUFFER_SIZE_2, RG16F, 1)
-    SAMPLER(Sample_Common_2, Render_Common_2)
+    TEXTURE(Render_Common_2_A, BUFFER_SIZE_2, RG16F, 1)
+    SAMPLER(Sample_Common_2_A, Render_Common_2_A)
+
+    TEXTURE(Render_Common_2_B, BUFFER_SIZE_2, RG16F, 1)
+    SAMPLER(Sample_Common_2_B, Render_Common_2_B)
 
     TEXTURE(Render_Common_3, BUFFER_SIZE_3, RG16F, 1)
     SAMPLER(Sample_Common_3, Render_Common_3)
@@ -160,7 +163,7 @@ namespace OpticalFlow
     TEXTURE(Render_Common_1_C, BUFFER_SIZE_1, RG16F, 9)
     SAMPLER(Sample_Common_1_C, Render_Common_1_C)
 
-    TEXTURE(Render_Optical_Flow, BUFFER_SIZE_1, RG16F, 1)
+    TEXTURE(Render_Optical_Flow, BUFFER_SIZE_1, RG16F, 9)
     SAMPLER(Sample_Optical_Flow, Render_Optical_Flow)
 
     // Optical flow visualization
@@ -172,7 +175,34 @@ namespace OpticalFlow
 
     SAMPLER(Sample_Color_Gamma, Render_Color)
 
-    // Vertex Shaders
+    /*
+        [Vertex Shaders]
+
+        [1] Velocity streaming and shading
+            https://github.com/diwi/PixelFlow
+
+            MIT License
+
+            Copyright (c) 2016 Thomas Diewald
+
+            Permission is hereby granted, free of charge, to any person obtaining a copy
+            of this software and associated documentation files (the "Software"), to deal
+            in the Software without restriction, including without limitation the rights
+            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+            copies of the Software, and to permit persons to whom the Software is
+            furnished to do so, subject to the following conditions:
+
+            The above copyright notice and this permission notice shall be included in all
+            copies or substantial portions of the Software.
+
+            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+            FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+            SOFTWARE.
+    */
 
     void Basic_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float2 TexCoord : TEXCOORD0)
     {
@@ -212,6 +242,32 @@ namespace OpticalFlow
         {
             TexCoords[i] = CoordVS.xxxy + (BlurOffsets[i].yzwx / BUFFER_SIZE_1.xxxy);
             TexCoords[i + 3] = CoordVS.xxxy - (BlurOffsets[i].yzwx / BUFFER_SIZE_1.xxxy);
+        }
+    }
+
+    void Blur_0_P_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[7] : TEXCOORD0)
+    {
+        float2 CoordVS = 0.0;
+        Basic_VS(ID, Position, CoordVS);
+        TexCoords[0] = CoordVS.xyxy;
+
+        for(int i = 1; i < 4; i++)
+        {
+            TexCoords[i] = CoordVS.xyyy + (BlurOffsets[i].xyzw / BUFFER_SIZE_2.xyyy);
+            TexCoords[i + 3] = CoordVS.xyyy - (BlurOffsets[i].xyzw / BUFFER_SIZE_2.xyyy);
+        }
+    }
+
+    void Blur_1_P_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[7] : TEXCOORD0)
+    {
+        float2 CoordVS = 0.0;
+        Basic_VS(ID, Position, CoordVS);
+        TexCoords[0] = CoordVS.xyxy;
+
+        for(int i = 1; i < 4; i++)
+        {
+            TexCoords[i] = CoordVS.xxxy + (BlurOffsets[i].yzwx / BUFFER_SIZE_2.xxxy);
+            TexCoords[i + 3] = CoordVS.xxxy - (BlurOffsets[i].yzwx / BUFFER_SIZE_2.xxxy);
         }
     }
 
@@ -268,7 +324,7 @@ namespace OpticalFlow
         float2 VelocityCoord = 0.0;
         VelocityCoord.xy = Origin.xy * PixelSize.xy;
         VelocityCoord.y = 1.0 - VelocityCoord.y;
-        Velocity = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_A, float4(VelocityCoord, 0.0, _MipBias)).xy;
+        Velocity = tex2Dlod(Shared_Resources_Flow::Sample_Common_2_A, float4(VelocityCoord, 0.0, _MipBias)).xy;
 
         // Scale velocity
         float2 Direction = Velocity * VELOCITY_SCALE;
@@ -300,12 +356,65 @@ namespace OpticalFlow
         Position = float4(VertexPositionNormal * 2.0 - 1.0, 0.0, 1.0); // ndc: [-1, +1]
     }
 
-    // Pixel Shaders
+    /*
+        [Pixel Shaders]
+
+        [1] Generate normals
+            https://github.com/crosire/reshade-shaders/blob/slim/Shaders/DisplayDepth.fx
+
+        [2] Normal encoding
+            https://knarkowicz.wordpress.com/2014/04/16/octahedron-normal-vector-encoding/
+
+        [3] Polar-coordinate diagram
+            https://opg.optica.org/josaa/fulltext.cfm?uri=josaa-37-11-1721&id=440913
+
+                @article{buzzelli2020arc,
+                    title = {ARC: Angle-Retaining Chromaticity diagram for color constancy error analysis},
+                    author = {Marco Buzzelli and Simone Bianco and Raimondo Schettini},
+                    journal = {J. Opt. Soc. Am. A},
+                    number = {11},
+                    pages = {1721--1730},
+                    publisher = {OSA},
+                    volume = {37},
+                    month = {Nov},
+                    year = {2020},
+                    doi = {10.1364/JOSAA.398692}
+                }
+
+        [4] Horn-Schunck Optical Flow
+            https://github.com/Dtananaev/cv_opticalFlow
+
+                Copyright (c) 2014-2015, Denis Tananaev All rights reserved.
+
+                Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+                Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+                Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+                documentation and/or other materials provided with the distribution.
+
+                THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+                INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+                DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+                EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+                LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+                STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+                ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+        [5] Robert's cross operator
+            https://homepages.inf.ed.ac.uk/rbf/HIPR2/roberts.htm
+
+        [6] Prewitt compass operator
+            https://homepages.inf.ed.ac.uk/rbf/HIPR2/prewitt.htm
+    */
 
     void Normalize_Frame_PS(in float4 Position : SV_POSITION, float2 TexCoord : TEXCOORD, out float2 Color : SV_TARGET0)
     {
         float4 Frame = max(tex2D(Sample_Color, TexCoord), exp2(-10.0));
-        Color.xy = saturate(Frame.xy / dot(Frame.rgb, 1.0));
+        // Convert RGB into ARC's polar coordinates [3]
+        // Append "FP16_MINIMUM" to avoid dividing by zero
+        Color.x = saturate(acos(dot(Frame.rgb, 1.0) / (sqrt(3.0) * length(Frame.rgb))));
+        Color.y = atan2(dot(Frame.gb, float2(sqrt(3.0), -sqrt(3.0))), dot(Frame.rgb, float3(2.0, -1.0, -1.0)) + FP16_MINIMUM);
     }
 
     void Blit_Frame_PS(in float4 Position : SV_POSITION, float2 TexCoord : TEXCOORD, out float4 OutputColor0 : SV_TARGET0)
@@ -378,11 +487,20 @@ namespace OpticalFlow
         Gaussian_Blur(Shared_Resources_Flow::Sample_Common_1_B, TexCoords, true, OutputColor0);
     }
 
+    // Turn the packed angle vector into its respective unit vectors
+    float3 HS_Units_2D(sampler2D Source, float2 TexCoord)
+    {
+        float3 Color = tex2D(Source, TexCoord).xyz;
+        sincos(Color.y, Color.z, Color.y);
+        Color.zy = saturate(Color.zy * 0.5 + 0.5);
+        return Color;
+    }
+
     void Derivatives_Z_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
     {
-        float2 Current = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoord).xy;
-        float2 Previous = tex2D(Sample_Common_1_C, TexCoord).xy;
-        OutputColor0 = dot(Current - Previous, 1.0);
+        float3 Current = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoord);
+        float3 Previous = HS_Units_2D(Sample_Common_1_C, TexCoord);
+        OutputColor0 = dot(Current - Previous, float3(0.95, 0.025, 0.025));
     }
 
     void Derivatives_XY_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
@@ -392,42 +510,29 @@ namespace OpticalFlow
         // A0     A1
         // A2     B0
         //   C0 C1
-        float2 A0 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].xw).xy * 4.0; // <-1.5, +0.5>
-        float2 A1 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].yw).xy * 4.0; // <+1.5, +0.5>
-        float2 A2 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].xz).xy * 4.0; // <-1.5, -0.5>
-        float2 B0 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].yz).xy * 4.0; // <+1.5, -0.5>
-        float2 B1 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].xw).xy * 4.0; // <-0.5, +1.5>
-        float2 B2 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].yw).xy * 4.0; // <+0.5, +1.5>
-        float2 C0 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].xz).xy * 4.0; // <-0.5, -1.5>
-        float2 C1 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].yz).xy * 4.0; // <+0.5, -1.5>
+        float3 A0 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].xw) * 4.0; // <-1.5, +0.5>
+        float3 A1 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].yw) * 4.0; // <+1.5, +0.5>
+        float3 A2 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].xz) * 4.0; // <-1.5, -0.5>
+        float3 B0 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].yz) * 4.0; // <+1.5, -0.5>
+        float3 B1 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].xw) * 4.0; // <-0.5, +1.5>
+        float3 B2 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].yw) * 4.0; // <+0.5, +1.5>
+        float3 C0 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].xz) * 4.0; // <-0.5, -1.5>
+        float3 C1 = HS_Units_2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].yz) * 4.0; // <+0.5, -1.5>
 
         OutputColor0 = 0.0;
-        float2 Ix = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
-        float2 Iy = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
-        OutputColor0.x = dot(Ix, 1.0);
-        OutputColor0.y = dot(Iy, 1.0);
+        float3 Ix = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
+        float3 Iy = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
+        OutputColor0.x = dot(Ix, float3(0.95, 0.025, 0.025));
+        OutputColor0.y = dot(Iy, float3(0.95, 0.025, 0.025));
     }
-
-    /*
-        https://github.com/Dtananaev/cv_opticalFlow
-
-        Copyright (c) 2014-2015, Denis Tananaev All rights reserved.
-
-        Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-        Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-        Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-    */
 
     #define COARSEST_LEVEL 5
 
+    // Calculate first level of Horn-Schunck Optical Flow [4]
     void Coarse_Optical_Flow_TV(in float2 TexCoord, in float Level, in float4 UV, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 6e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 SD = tex2Dlod(Sample_Common_1_C, float4(TexCoord, 0.0, Level + 0.5)).xy;
@@ -457,7 +562,7 @@ namespace OpticalFlow
 
     void Gradient(in float4x2 Samples, out float Gradient)
     {
-        // 2x2 Robert's cross
+        // 2x2 Robert's cross [5]
         // [0] [2]
         // [1] [3]
         float4 SqGradientUV = 0.0;
@@ -486,8 +591,7 @@ namespace OpticalFlow
 
     void Process_Gradients(in float2 SampleUV[9], inout float4 AreaGrad, inout float4 UVGradient)
     {
-        // Center smoothness gradient using Prewitt compass
-        // https://homepages.inf.ed.ac.uk/rbf/HIPR2/prewitt.htm
+        // Calculate center gradient using Prewitt compass operator [6]
         // 0.xy           | 0.zw           | 1.xy           | 1.zw           | 2.xy           | 2.zw           | 3.xy           | 3.zw
         // .......................................................................................................................................
         // -1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 -1.0 | +1.0 -1.0 -1.0 | -1.0 -1.0 -1.0 | -1.0 -1.0 +1.0 |
@@ -530,25 +634,20 @@ namespace OpticalFlow
         Color = (SampleNW + SampleNE + SampleSW + SampleSE) * 0.25;
     }
 
+    // Calculate following levels of Horn-Schunck Optical Flow [4]
     void Optical_Flow_TV(in sampler2D SourceUV, in float4 TexCoords[3], in float Level, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 6e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 SD = tex2Dlod(Sample_Common_1_C, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
         float TD = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_B, float4(TexCoords[1].xz, 0.0, Level + 0.5)).x;
 
         // Optical flow calculation
-
-        // <Ru, Rv, Gu, Gv>
         float2 SampleUV[9];
-
-        // [0] = Red, [1] = Green
         float4 AreaGrad;
         float4 UVGradient;
-
-        // <Ru, Rv, Gu, Gv>
         float2 AreaAvg[4];
         float4 CenterAverage;
         float4 UVAverage;
@@ -626,26 +725,30 @@ namespace OpticalFlow
     void Level_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[3] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
         OutputColor0 = 0.0;
-        Optical_Flow_TV(Shared_Resources_Flow::Sample_Common_2, TexCoords, 0.0, OutputColor0.xy);
+        Optical_Flow_TV(Shared_Resources_Flow::Sample_Common_2_A, TexCoords, 0.0, OutputColor0.xy);
         OutputColor0.ba = float2(0.0, _BlendFactor);
     }
 
-    void Post_Blur_0_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0, out float4 OutputColor1 : SV_TARGET1)
+    void Copy_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
+    {
+        OutputColor0 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoord);
+    }
+
+    void Post_Blur_0_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
         Gaussian_Blur(Sample_Optical_Flow, TexCoords, false, OutputColor0);
         OutputColor0.a = 1.0;
-        OutputColor1 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].xy);
     }
 
     void Post_Blur_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
-        Gaussian_Blur(Shared_Resources_Flow::Sample_Common_1_B, TexCoords, true, OutputColor0);
+        Gaussian_Blur(Shared_Resources_Flow::Sample_Common_2_B, TexCoords, true, OutputColor0);
         OutputColor0.a = 1.0;
     }
 
     void Velocity_Shading_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float4 OutputColor0 : SV_Target)
     {
-        float2 Velocity = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_A, float4(TexCoord, 0.0, _MipBias)).xy;
+        float2 Velocity = tex2Dlod(Shared_Resources_Flow::Sample_Common_2_A, float4(TexCoord, 0.0, _MipBias)).xy;
 
         if(_NormalizedShading)
         {
@@ -708,7 +811,7 @@ namespace OpticalFlow
         PASS(Sample_3x3_6_VS, Level_5_PS, Shared_Resources_Flow::Render_Common_5)
         PASS(Sample_3x3_5_VS, Level_4_PS, Shared_Resources_Flow::Render_Common_4)
         PASS(Sample_3x3_4_VS, Level_3_PS, Shared_Resources_Flow::Render_Common_3)
-        PASS(Sample_3x3_3_VS, Level_2_PS, Shared_Resources_Flow::Render_Common_2)
+        PASS(Sample_3x3_3_VS, Level_2_PS, Shared_Resources_Flow::Render_Common_2_A)
 
         pass
         {
@@ -722,21 +825,12 @@ namespace OpticalFlow
             DestBlend = SRCALPHA;
         }
 
-        // Gaussian blur
-        pass // Do gaussian blur 0 and copy current convolved frame for next frame
-        {
-            VertexShader = Blur_0_VS;
-            PixelShader = Post_Blur_0_PS;
-            RenderTarget0 = Shared_Resources_Flow::Render_Common_1_B;
-            RenderTarget1 = Render_Common_1_C;
-        }
+        // Copy current convolved frame for next frame
+        PASS(Basic_VS, Copy_PS, Render_Common_1_C)
 
-        pass
-        {
-            VertexShader = Blur_1_VS;
-            PixelShader = Post_Blur_1_PS;
-            RenderTarget0 = Shared_Resources_Flow::Render_Common_1_A;
-        }
+        // Gaussian blur
+        PASS(Blur_0_P_VS, Post_Blur_0_PS, Shared_Resources_Flow::Render_Common_2_B)
+        PASS(Blur_1_P_VS, Post_Blur_1_PS, Shared_Resources_Flow::Render_Common_2_A)
 
         // Visualize optical flow
 

--- a/shaders/cOpticalFlow.fx
+++ b/shaders/cOpticalFlow.fx
@@ -71,34 +71,28 @@
 
 namespace Shared_Resources_Flow
 {
-    // Store convoluted normalized frame 1 and 3
-
     TEXTURE(Render_Common_0, int2(BUFFER_WIDTH >> 1, BUFFER_HEIGHT >> 1), RG16F, 4)
     SAMPLER(Sample_Common_0, Render_Common_0)
-
-    // Normalized, prefiltered frames for processing
 
     TEXTURE(Render_Common_1_A, BUFFER_SIZE_1, RG16F, 9)
     SAMPLER(Sample_Common_1_A, Render_Common_1_A)
 
-    TEXTURE(Render_Common_1_B, BUFFER_SIZE_1, RGBA16F, 9)
+    TEXTURE(Render_Common_1_B, BUFFER_SIZE_1, RG16F, 9)
     SAMPLER(Sample_Common_1_B, Render_Common_1_B)
 
-    // Levels
-
-    TEXTURE(Render_Common_2, BUFFER_SIZE_2, RGBA16F, 1)
+    TEXTURE(Render_Common_2, BUFFER_SIZE_2, RG16F, 1)
     SAMPLER(Sample_Common_2, Render_Common_2)
 
-    TEXTURE(Render_Common_3, BUFFER_SIZE_3, RGBA16F, 1)
+    TEXTURE(Render_Common_3, BUFFER_SIZE_3, RG16F, 1)
     SAMPLER(Sample_Common_3, Render_Common_3)
 
-    TEXTURE(Render_Common_4, BUFFER_SIZE_4, RGBA16F, 1)
+    TEXTURE(Render_Common_4, BUFFER_SIZE_4, RG16F, 1)
     SAMPLER(Sample_Common_4, Render_Common_4)
 
-    TEXTURE(Render_Common_5, BUFFER_SIZE_5, RGBA16F, 1)
+    TEXTURE(Render_Common_5, BUFFER_SIZE_5, RG16F, 1)
     SAMPLER(Sample_Common_5, Render_Common_5)
 
-    TEXTURE(Render_Common_6, BUFFER_SIZE_6, RGBA16F, 1)
+    TEXTURE(Render_Common_6, BUFFER_SIZE_6, RG16F, 1)
     SAMPLER(Sample_Common_6, Render_Common_6)
 }
 
@@ -384,7 +378,7 @@ namespace OpticalFlow
         Gaussian_Blur(Shared_Resources_Flow::Sample_Common_1_B, TexCoords, true, OutputColor0);
     }
 
-    void Derivatives_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
+    void Derivatives_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
     {
         // Bilinear 5x5 Sobel by CeeJayDK
         //   B1 B2
@@ -401,8 +395,10 @@ namespace OpticalFlow
         float2 C1 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[1].yz).xy * 4.0; // <+0.5, -1.5>
 
         OutputColor0 = 0.0;
-        OutputColor0.xz = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
-        OutputColor0.yw = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
+        float2 Ix = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
+        float2 Iy = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
+        OutputColor0.x = dot(Ix, 1.0);
+        OutputColor0.y = dot(Iy, 1.0);
     }
 
     /*
@@ -421,41 +417,41 @@ namespace OpticalFlow
 
     #define COARSEST_LEVEL 5
 
-    void Coarse_Optical_Flow_TV(in float2 TexCoord, in float Level, in float4 UV, out float4 OpticalFlow)
+    void Coarse_Optical_Flow_TV(in float2 TexCoord, in float Level, in float4 UV, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 1e-3) / exp2(COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 Current = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_A, float4(TexCoord, 0.0, Level + 0.5)).xy;
         float2 Previous = tex2Dlod(Sample_Common_1_P, float4(TexCoord, 0.0, Level + 0.5)).xy;
 
         // <Rx, Gx, Ry, Gy>
-        float4 SD = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_B, float4(TexCoord, 0.0, Level + 0.5));
+        float2 SD = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_B, float4(TexCoord, 0.0, Level + 0.5)).xy;
 
         // <Rz, Gz>
-        float2 TD = Current - Previous;
+        float TD = dot(Current - Previous, 1.0);
 
-        float2 C = 0.0;
-        float4 Aii = 0.0;
-        float2 Aij = 0.0;
-        float4 Bi = 0.0;
+        float C = 0.0;
+        float2 Aii = 0.0;
+        float Aij = 0.0;
+        float2 Bi = 0.0;
 
         // Calculate constancy assumption nonlinearity
-        C = rsqrt((TD.rg * TD.rg) + FP16_MINIMUM);
+        C = rsqrt((TD * TD) + FP16_MINIMUM);
 
         // Build linear equation
         // [Aii Aij] [X] = [Bi]
         // [Aij Aii] [Y] = [Bi]
-        Aii = 1.0 / (C.rrgg * (SD.xyzw * SD.xyzw) + Alpha);
-        Aij = C.rg * (SD.xz * SD.yw);
-        Bi = C.rrgg * (SD.xyzw * TD.rrgg);
+        Aii = 1.0 / (C * (SD.xy * SD.xy) + Alpha);
+        Aij = C * (SD.x * SD.y);
+        Bi = C * (SD.xy * TD);
 
         // Solve linear equation for [U, V]
         // [Ix^2+A IxIy] [U] = -[IxIt]
         // [IxIy Iy^2+A] [V] = -[IyIt]
-        OpticalFlow.xz = Aii.xz * ((Alpha * UV.xz) - (Aij.rg * UV.yw) - Bi.xz);
-        OpticalFlow.yw = Aii.yw * ((Alpha * UV.yw) - (Aij.rg * OpticalFlow.xz) - Bi.yw);
+        OpticalFlow.x = Aii.x * ((Alpha * UV.x) - (Aij * UV.y) - Bi.x);
+        OpticalFlow.y = Aii.y * ((Alpha * UV.y) - (Aij * OpticalFlow.x) - Bi.y);
     }
 
     void Gradient(in float4x2 Samples, out float Gradient)
@@ -528,39 +524,37 @@ namespace OpticalFlow
         UVGradient = 0.5 * (CenterGradient + AreaGrad);
     }
 
-    void Area_Average(in float4 SampleNW, in float4 SampleNE, in float4 SampleSW, in float4 SampleSE, out float4 Color)
+    void Area_Average(in float2 SampleNW, in float2 SampleNE, in float2 SampleSW, in float2 SampleSE, out float2 Color)
     {
         Color = (SampleNW + SampleNE + SampleSW + SampleSE) * 0.25;
     }
 
-    void Optical_Flow_TV(in sampler2D SourceUV, in float4 TexCoords[3], in float Level, out float4 OpticalFlow)
+    void Optical_Flow_TV(in sampler2D SourceUV, in float4 TexCoords[3], in float Level, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 1e-3) / exp2(COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 Current = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_A, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
         float2 Previous = tex2Dlod(Sample_Common_1_P, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
 
-        // <Rx, Gx, Ry, Gy>
-        float4 SD = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_B, float4(TexCoords[1].xz, 0.0, Level + 0.5));
+        // <Rx, Ry, Gx, Gy>
+        float2 SD = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_B, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
 
         // <Rz, Gz>
-        float2 TD = Current - Previous;
+        float TD = dot(Current - Previous, 1.0);
 
         // Optical flow calculation
 
         // <Ru, Rv, Gu, Gv>
-        float4 SampleUV[9];
-        float2 SampleUVR[9];
-        float2 SampleUVG[9];
+        float2 SampleUV[9];
 
         // [0] = Red, [1] = Green
-        float4 AreaGrad[2];
-        float4 UVGradient[2];
+        float4 AreaGrad;
+        float4 UVGradient;
 
         // <Ru, Rv, Gu, Gv>
-        float4 AreaAvg[4];
+        float2 AreaAvg[4];
         float4 CenterAverage;
         float4 UVAverage;
 
@@ -568,29 +562,20 @@ namespace OpticalFlow
         // 0 3 6
         // 1 4 7
         // 2 5 8
-        SampleUV[0] = tex2D(SourceUV, TexCoords[0].xy);
-        SampleUV[1] = tex2D(SourceUV, TexCoords[0].xz);
-        SampleUV[2] = tex2D(SourceUV, TexCoords[0].xw);
-        SampleUV[3] = tex2D(SourceUV, TexCoords[1].xy);
-        SampleUV[4] = tex2D(SourceUV, TexCoords[1].xz);
-        SampleUV[5] = tex2D(SourceUV, TexCoords[1].xw);
-        SampleUV[6] = tex2D(SourceUV, TexCoords[2].xy);
-        SampleUV[7] = tex2D(SourceUV, TexCoords[2].xz);
-        SampleUV[8] = tex2D(SourceUV, TexCoords[2].xw);
-
-        [unroll]for(int i = 0; i < 9; i++)
-        {
-            SampleUVR[i] = SampleUV[i].xy;
-            SampleUVG[i] = SampleUV[i].zw;
-        }
+        SampleUV[0] = tex2D(SourceUV, TexCoords[0].xy).xy;
+        SampleUV[1] = tex2D(SourceUV, TexCoords[0].xz).xy;
+        SampleUV[2] = tex2D(SourceUV, TexCoords[0].xw).xy;
+        SampleUV[3] = tex2D(SourceUV, TexCoords[1].xy).xy;
+        SampleUV[4] = tex2D(SourceUV, TexCoords[1].xz).xy;
+        SampleUV[5] = tex2D(SourceUV, TexCoords[1].xw).xy;
+        SampleUV[6] = tex2D(SourceUV, TexCoords[2].xy).xy;
+        SampleUV[7] = tex2D(SourceUV, TexCoords[2].xz).xy;
+        SampleUV[8] = tex2D(SourceUV, TexCoords[2].xw).xy;
 
         // Process area gradients in each patch, per plane
-
-        Process_Gradients(SampleUVR, AreaGrad[0], UVGradient[0]);
-        Process_Gradients(SampleUVG, AreaGrad[1], UVGradient[1]);
+        Process_Gradients(SampleUV, AreaGrad, UVGradient);
 
         // Calculate area + center averages of estimated vectors
-
         Area_Average(SampleUV[0], SampleUV[3], SampleUV[1], SampleUV[4], AreaAvg[0]);
         Area_Average(SampleUV[3], SampleUV[6], SampleUV[4], SampleUV[7], AreaAvg[1]);
         Area_Average(SampleUV[1], SampleUV[4], SampleUV[2], SampleUV[5], AreaAvg[2]);
@@ -601,41 +586,39 @@ namespace OpticalFlow
         CenterAverage += (SampleUV[4] * 4.0);
         CenterAverage = CenterAverage / 16.0;
 
-        float2 C = 0.0;
-        float4 Aii = 0.0;
-        float2 Aij = 0.0;
-        float4 Bi = 0.0;
+        float C = 0.0;
+        float2 Aii = 0.0;
+        float Aij = 0.0;
+        float2 Bi = 0.0;
 
         // Calculate constancy assumption nonlinearity
         // Dot-product increases when the current gradient + previous estimation are parallel
-        C.r = dot(SD.xy, CenterAverage.xy) + TD.r;
-        C.g = dot(SD.zw, CenterAverage.zw) + TD.g;
-        C.rg = rsqrt((C.rg * C.rg) + FP16_MINIMUM);
+        // IxU + IyV = -It -> IxU + IyV + It = 0.0
+        C = dot(SD.xy, CenterAverage.xy) + TD;
+        C = rsqrt((C * C) + FP16_MINIMUM);
 
         // Build linear equation
         // [Aii Aij] [X] = [Bi]
         // [Aij Aii] [Y] = [Bi]
-        Aii.xy = 1.0 / (dot(UVGradient[0], 1.0) * Alpha + (C.rr * (SD.xy * SD.xy)));
-        Aii.zw = 1.0 / (dot(UVGradient[1], 1.0) * Alpha + (C.gg * (SD.zw * SD.zw)));
-        Aij.xy = C.rg * (SD.xz * SD.yw);
-        Bi = C.rrgg * (SD.xyzw * TD.rrgg);
+        Aii = 1.0 / (dot(UVGradient, 1.0) * Alpha + (C * (SD.xy * SD.xy)));
+        Aij = C * (SD.x * SD.y);
+        Bi = C * (SD.xy * TD);
 
         // Solve linear equation for [U, V]
         // [Ix^2+A IxIy] [U] = -[IxIt]
         // [IxIy Iy^2+A] [V] = -[IyIt]
-        UVAverage.xy = (AreaGrad[0].xx * AreaAvg[0].xy) + (AreaGrad[0].yy * AreaAvg[1].xy) + (AreaGrad[0].zz * AreaAvg[2].xy) + (AreaGrad[0].ww * AreaAvg[3].xy);
-        UVAverage.zw = (AreaGrad[1].xx * AreaAvg[0].zw) + (AreaGrad[1].yy * AreaAvg[1].zw) + (AreaGrad[1].zz * AreaAvg[2].zw) + (AreaGrad[1].ww * AreaAvg[3].zw);
-        OpticalFlow.xz = Aii.xz * ((Alpha * UVAverage.xz) - (Aij.rg * CenterAverage.yw) - Bi.xz);
-        OpticalFlow.yw = Aii.yw * ((Alpha * UVAverage.yw) - (Aij.rg * OpticalFlow.xz) - Bi.yw);
+        UVAverage.xy = (AreaGrad.xx * AreaAvg[0]) + (AreaGrad.yy * AreaAvg[1]) + (AreaGrad.zz * AreaAvg[2]) + (AreaGrad.ww * AreaAvg[3]);
+        OpticalFlow.x = Aii.x * ((Alpha * UVAverage.x) - (Aij * CenterAverage.y) - Bi.x);
+        OpticalFlow.y = Aii.y * ((Alpha * UVAverage.y) - (Aij * OpticalFlow.x) - Bi.y);
     }
 
     #define LEVEL_PS(NAME, SAMPLER, LEVEL)                                                                             \
-        void NAME(in float4 Position : SV_POSITION, in float4 TexCoords[3] : TEXCOORD0, out float4 Color : SV_TARGET0) \
+        void NAME(in float4 Position : SV_POSITION, in float4 TexCoords[3] : TEXCOORD0, out float2 Color : SV_TARGET0) \
         {                                                                                                              \
             Optical_Flow_TV(SAMPLER, TexCoords, LEVEL, Color);                                                         \
         }
 
-    void Level_6_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float4 Color : SV_TARGET0)
+    void Level_6_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float2 Color : SV_TARGET0)
     {
         Coarse_Optical_Flow_TV(TexCoord, 5.0, 0.0, Color);
     }
@@ -647,9 +630,8 @@ namespace OpticalFlow
 
     void Level_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[3] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
-        float4 OpticalFlow = 0.0;
-        Optical_Flow_TV(Shared_Resources_Flow::Sample_Common_2, TexCoords, 0.0, OpticalFlow);
-        OutputColor0.rg = OpticalFlow.xy + OpticalFlow.zw;
+        OutputColor0 = 0.0;
+        Optical_Flow_TV(Shared_Resources_Flow::Sample_Common_2, TexCoords, 0.0, OutputColor0.xy);
         OutputColor0.ba = float2(0.0, _BlendFactor);
     }
 

--- a/shaders/cOpticalFlow.fx
+++ b/shaders/cOpticalFlow.fx
@@ -187,41 +187,37 @@ namespace OpticalFlow
         Position = float4(TexCoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
     }
 
-    static const float2 BlurOffsets[8] =
+    static const float4 BlurOffsets[4] =
     {
-        float2(0.0, 0.0),
-        float2(0.0, 1.4850045),
-        float2(0.0, 3.4650571),
-        float2(0.0, 5.445221),
-        float2(0.0, 7.4255576),
-        float2(0.0, 9.406127),
-        float2(0.0, 11.386987),
-        float2(0.0, 13.368189)
+        float4(0.0, 0.0, 0.0, 0.0),
+        float4(0.0, 1.490652, 3.4781995, 5.465774),
+        float4(0.0, 7.45339, 9.441065, 11.42881),
+        float4(0.0, 13.416645, 15.404578, 17.392626)
     };
 
-    void Blur_0_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[8] : TEXCOORD0)
+    void Blur_0_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[7] : TEXCOORD0)
     {
         float2 CoordVS = 0.0;
         Basic_VS(ID, Position, CoordVS);
         TexCoords[0] = CoordVS.xyxy;
 
-        for(int i = 1; i < 8; i++)
+        for(int i = 1; i < 4; i++)
         {
-            TexCoords[i].xy = CoordVS.xy - (BlurOffsets[i].yx / BUFFER_SIZE_1);
-            TexCoords[i].zw = CoordVS.xy + (BlurOffsets[i].yx / BUFFER_SIZE_1);
+            TexCoords[i] = CoordVS.xyyy + (BlurOffsets[i].xyzw / BUFFER_SIZE_1.xyyy);
+            TexCoords[i + 3] = CoordVS.xyyy - (BlurOffsets[i].xyzw / BUFFER_SIZE_1.xyyy);
         }
     }
 
-    void Blur_1_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[8] : TEXCOORD0)
+    void Blur_1_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[7] : TEXCOORD0)
     {
         float2 CoordVS = 0.0;
         Basic_VS(ID, Position, CoordVS);
         TexCoords[0] = CoordVS.xyxy;
 
-        for(int i = 1; i < 8; i++)
+        for(int i = 1; i < 4; i++)
         {
-            TexCoords[i].xy = CoordVS.xy - (BlurOffsets[i].xy / BUFFER_SIZE_1);
-            TexCoords[i].zw = CoordVS.xy + (BlurOffsets[i].xy / BUFFER_SIZE_1);
+            TexCoords[i] = CoordVS.xxxy + (BlurOffsets[i].yzwx / BUFFER_SIZE_1.xxxy);
+            TexCoords[i + 3] = CoordVS.xxxy - (BlurOffsets[i].yzwx / BUFFER_SIZE_1.xxxy);
         }
     }
 
@@ -323,41 +319,69 @@ namespace OpticalFlow
         OutputColor0 = tex2D(Shared_Resources_Flow::Sample_Common_0, TexCoord);
     }
 
-    static const float BlurWeights[8] =
+    static const float BlurWeights[10] =
     {
-        0.079788454,
-        0.15186256,
-        0.12458323,
-        0.08723135,
-        0.05212966,
-        0.026588224,
-        0.011573823,
-        0.0042996835
+        0.06299088,
+        0.122137636,
+        0.10790718,
+        0.08633988,
+        0.062565096,
+        0.04105926,
+        0.024403222,
+        0.013135255,
+        0.006402994,
+        0.002826693
     };
 
-    void Gaussian_Blur(in sampler2D Source, in float4 TexCoords[8], out float4 OutputColor0)
+    void Gaussian_Blur(in sampler2D Source, in float4 TexCoords[7], bool Alt, out float4 OutputColor0)
     {
         float TotalWeights = BlurWeights[0];
         OutputColor0 = (tex2D(Source, TexCoords[0].xy) * BlurWeights[0]);
 
-        for(int i = 1; i < 8; i++)
+        int CoordIndex = 1;
+        int WeightIndex = 1;
+
+        while(CoordIndex < 4) // for(int i = 1; i < 4; i++)
         {
-            OutputColor0 += (tex2D(Source, TexCoords[i].xy) * BlurWeights[i]);
-            OutputColor0 += (tex2D(Source, TexCoords[i].zw) * BlurWeights[i]);
+            if(!Alt)
+            {
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex].xy) * BlurWeights[WeightIndex + 0]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex].xz) * BlurWeights[WeightIndex + 1]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex].xw) * BlurWeights[WeightIndex + 2]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex + 3].xy) * BlurWeights[WeightIndex + 0]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex + 3].xz) * BlurWeights[WeightIndex + 1]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex + 3].xw) * BlurWeights[WeightIndex + 2]);
+            }
+            else
+            {
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex].xw) * BlurWeights[WeightIndex + 0]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex].yw) * BlurWeights[WeightIndex + 1]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex].zw) * BlurWeights[WeightIndex + 2]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex + 3].xw) * BlurWeights[WeightIndex + 0]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex + 3].yw) * BlurWeights[WeightIndex + 1]);
+                OutputColor0 += (tex2D(Source, TexCoords[CoordIndex + 3].zw) * BlurWeights[WeightIndex + 2]);
+            }
+
+            CoordIndex = CoordIndex + 1;
+            WeightIndex = WeightIndex + 3;
+        }
+
+        for(int i = 1; i < 10; i++)
+        {
             TotalWeights += (BlurWeights[i] * 2.0);
         }
 
         OutputColor0 = OutputColor0 / TotalWeights;
     }
 
-    void Pre_Blur_0_PS(in float4 Position : SV_POSITION, in float4 TexCoords[8] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
+    void Pre_Blur_0_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
-        Gaussian_Blur(Shared_Resources_Flow::Sample_Common_1_A, TexCoords, OutputColor0);
+        Gaussian_Blur(Shared_Resources_Flow::Sample_Common_1_A, TexCoords, false, OutputColor0);
     }
 
-    void Pre_Blur_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[8] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
+    void Pre_Blur_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
-        Gaussian_Blur(Shared_Resources_Flow::Sample_Common_1_B, TexCoords, OutputColor0);
+        Gaussian_Blur(Shared_Resources_Flow::Sample_Common_1_B, TexCoords, true, OutputColor0);
     }
 
     void Derivatives_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
@@ -629,16 +653,16 @@ namespace OpticalFlow
         OutputColor0.ba = float2(0.0, _BlendFactor);
     }
 
-    void Post_Blur_0_PS(in float4 Position : SV_POSITION, in float4 TexCoords[8] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0, out float4 OutputColor1 : SV_TARGET1)
+    void Post_Blur_0_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0, out float4 OutputColor1 : SV_TARGET1)
     {
-        Gaussian_Blur(Sample_Optical_Flow, TexCoords, OutputColor0);
+        Gaussian_Blur(Sample_Optical_Flow, TexCoords, false, OutputColor0);
         OutputColor0.a = 1.0;
         OutputColor1 = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoords[0].xy);
     }
 
-    void Post_Blur_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[8] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
+    void Post_Blur_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[7] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
-        Gaussian_Blur(Shared_Resources_Flow::Sample_Common_1_B, TexCoords, OutputColor0);
+        Gaussian_Blur(Shared_Resources_Flow::Sample_Common_1_B, TexCoords, true, OutputColor0);
         OutputColor0.a = 1.0;
     }
 

--- a/shaders/cOpticalFlow.fx
+++ b/shaders/cOpticalFlow.fx
@@ -157,8 +157,8 @@ namespace OpticalFlow
         #endif
     };
 
-    TEXTURE(Render_Common_1_P, BUFFER_SIZE_1, RG16F, 9)
-    SAMPLER(Sample_Common_1_P, Render_Common_1_P)
+    TEXTURE(Render_Common_1_C, BUFFER_SIZE_1, RG16F, 9)
+    SAMPLER(Sample_Common_1_C, Render_Common_1_C)
 
     TEXTURE(Render_Optical_Flow, BUFFER_SIZE_1, RG16F, 1)
     SAMPLER(Sample_Optical_Flow, Render_Optical_Flow)
@@ -378,7 +378,14 @@ namespace OpticalFlow
         Gaussian_Blur(Shared_Resources_Flow::Sample_Common_1_B, TexCoords, true, OutputColor0);
     }
 
-    void Derivatives_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
+    void Derivatives_Z_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
+    {
+        float2 Current = tex2D(Shared_Resources_Flow::Sample_Common_1_A, TexCoord).xy;
+        float2 Previous = tex2D(Sample_Common_1_C, TexCoord).xy;
+        OutputColor0 = dot(Current - Previous, 1.0);
+    }
+
+    void Derivatives_XY_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
     {
         // Bilinear 5x5 Sobel by CeeJayDK
         //   B1 B2
@@ -423,14 +430,8 @@ namespace OpticalFlow
         const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
-        float2 Current = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_A, float4(TexCoord, 0.0, Level + 0.5)).xy;
-        float2 Previous = tex2Dlod(Sample_Common_1_P, float4(TexCoord, 0.0, Level + 0.5)).xy;
-
-        // <Rx, Gx, Ry, Gy>
-        float2 SD = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_B, float4(TexCoord, 0.0, Level + 0.5)).xy;
-
-        // <Rz, Gz>
-        float TD = dot(Current - Previous, 1.0);
+        float2 SD = tex2Dlod(Sample_Common_1_C, float4(TexCoord, 0.0, Level + 0.5)).xy;
+        float TD = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_B, float4(TexCoord, 0.0, Level + 0.5)).x;
 
         float C = 0.0;
         float2 Aii = 0.0;
@@ -535,14 +536,8 @@ namespace OpticalFlow
         const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
-        float2 Current = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_A, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
-        float2 Previous = tex2Dlod(Sample_Common_1_P, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
-
-        // <Rx, Ry, Gx, Gy>
-        float2 SD = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_B, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
-
-        // <Rz, Gz>
-        float TD = dot(Current - Previous, 1.0);
+        float2 SD = tex2Dlod(Sample_Common_1_C, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
+        float TD = tex2Dlod(Shared_Resources_Flow::Sample_Common_1_B, float4(TexCoords[1].xz, 0.0, Level + 0.5)).x;
 
         // Optical flow calculation
 
@@ -704,8 +699,9 @@ namespace OpticalFlow
         PASS(Blur_0_VS, Pre_Blur_0_PS, Shared_Resources_Flow::Render_Common_1_B)
         PASS(Blur_1_VS, Pre_Blur_1_PS, Shared_Resources_Flow::Render_Common_1_A) // Save this to store later
 
-        // Calculate spatial derivative pyramid
-        PASS(Derivatives_VS, Derivatives_PS, Shared_Resources_Flow::Render_Common_1_B)
+        // Calculate spatial and temporal derivative pyramid
+        PASS(Basic_VS, Derivatives_Z_PS, Shared_Resources_Flow::Render_Common_1_B)
+        PASS(Derivatives_VS, Derivatives_XY_PS, Render_Common_1_C)
 
         // Bilinear Optical Flow
         PASS(Basic_VS, Level_6_PS, Shared_Resources_Flow::Render_Common_6)
@@ -732,7 +728,7 @@ namespace OpticalFlow
             VertexShader = Blur_0_VS;
             PixelShader = Post_Blur_0_PS;
             RenderTarget0 = Shared_Resources_Flow::Render_Common_1_B;
-            RenderTarget1 = Render_Common_1_P;
+            RenderTarget1 = Render_Common_1_C;
         }
 
         pass

--- a/shaders/cOpticalFlow.fx
+++ b/shaders/cOpticalFlow.fx
@@ -526,15 +526,15 @@ namespace OpticalFlow
         // [1] [4] [7]
         // [2] [5] [8]
         float2 Output;
-        Output += (SampleUV[0] * Weights[0][0]);
-        Output += (SampleUV[1] * Weights[0][1]);
-        Output += (SampleUV[2] * Weights[0][2]);
-        Output += (SampleUV[3] * Weights[1][0]);
-        Output += (SampleUV[4] * Weights[1][1]);
-        Output += (SampleUV[5] * Weights[1][2]);
-        Output += (SampleUV[6] * Weights[2][0]);
-        Output += (SampleUV[7] * Weights[2][1]);
-        Output += (SampleUV[8] * Weights[2][2]);
+        Output += (SampleUV[0] * Weights._11);
+        Output += (SampleUV[1] * Weights._12);
+        Output += (SampleUV[2] * Weights._13);
+        Output += (SampleUV[3] * Weights._21);
+        Output += (SampleUV[4] * Weights._22);
+        Output += (SampleUV[5] * Weights._23);
+        Output += (SampleUV[6] * Weights._31);
+        Output += (SampleUV[7] * Weights._32);
+        Output += (SampleUV[8] * Weights._33);
         return Output;
     }
 
@@ -548,13 +548,13 @@ namespace OpticalFlow
         // -1.0 +1.0 +1.0 | -1.0 -1.0 +1.0 | -1.0 -1.0 -1.0 | +1.0 -1.0 -1.0 | +1.0 +1.0 -1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 |
 
         float4 PrewittUV[4];
-        PrewittUV[0].xy = Prewitt(SampleUV, float3x3(-1.0, -1.0, -1.0, +1.0, -2.0, +1.0, +1.0, +1.0, +1.0));
-        PrewittUV[0].zw = Prewitt(SampleUV, float3x3(+1.0, -1.0, -1.0, +1.0, -2.0, -1.0, +1.0, +1.0, +1.0));
-        PrewittUV[1].xy = Prewitt(SampleUV, float3x3(+1.0, +1.0, -1.0, +1.0, -2.0, -1.0, +1.0, +1.0, -1.0));
+        PrewittUV[0].xy = Prewitt(SampleUV, float3x3(-1.0, +1.0, +1.0, -1.0, -2.0, +1.0, -1.0, +1.0, +1.0));
+        PrewittUV[0].zw = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, -1.0, -2.0, +1.0, -1.0, -1.0, +1.0));
+        PrewittUV[1].xy = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, +1.0, -2.0, +1.0, -1.0, -1.0, -1.0));
         PrewittUV[1].zw = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, +1.0, -2.0, -1.0, +1.0, -1.0, -1.0));
-        PrewittUV[2].xy = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, +1.0, -2.0, +1.0, -1.0, -1.0, -1.0));
-        PrewittUV[2].zw = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, -1.0, -2.0, +1.0, -1.0, -1.0, +1.0));
-        PrewittUV[3].xy = Prewitt(SampleUV, float3x3(-1.0, +1.0, +1.0, -1.0, -2.0, +1.0, -1.0, +1.0, +1.0));
+        PrewittUV[2].xy = Prewitt(SampleUV, float3x3(+1.0, +1.0, -1.0, +1.0, -2.0, -1.0, +1.0, +1.0, -1.0));
+        PrewittUV[2].zw = Prewitt(SampleUV, float3x3(+1.0, -1.0, -1.0, +1.0, -2.0, -1.0, +1.0, +1.0, +1.0));
+        PrewittUV[3].xy = Prewitt(SampleUV, float3x3(-1.0, -1.0, -1.0, +1.0, -2.0, +1.0, +1.0, +1.0, +1.0));
         PrewittUV[3].zw = Prewitt(SampleUV, float3x3(-1.0, -1.0, +1.0, -1.0, -2.0, +1.0, +1.0, +1.0, +1.0));
 
         float2 MaxGradient[3];
@@ -563,7 +563,7 @@ namespace OpticalFlow
 
         const float Weight = 1.0 / 5.0;
         MaxGradient[2] = max(abs(MaxGradient[0]), abs(MaxGradient[1])) * Weight;
-        float CenterGradient = rsqrt((dot(MaxGradient[2], MaxGradient[2]) * 0.5) + FP16_MINIMUM);
+        float CenterGradient = rsqrt((dot(MaxGradient[2], MaxGradient[2])) + FP16_MINIMUM);
 
         // Area smoothness gradients
         // .............................

--- a/shaders/kDatamosh.fx
+++ b/shaders/kDatamosh.fx
@@ -301,7 +301,7 @@ namespace Datamosh
         int CoordIndex = 1;
         int WeightIndex = 1;
 
-        while(CoordIndex < 4) // for(int i = 1; i < 4; i++)
+        while(CoordIndex < 4)
         {
             if(!Alt)
             {

--- a/shaders/kDatamosh.fx
+++ b/shaders/kDatamosh.fx
@@ -489,22 +489,21 @@ namespace Datamosh
         // [1] [4] [7]
         // [2] [5] [8]
         float2 Output;
-        Output += (SampleUV[0] * Weights[0][0]);
-        Output += (SampleUV[1] * Weights[0][1]);
-        Output += (SampleUV[2] * Weights[0][2]);
-        Output += (SampleUV[3] * Weights[1][0]);
-        Output += (SampleUV[4] * Weights[1][1]);
-        Output += (SampleUV[5] * Weights[1][2]);
-        Output += (SampleUV[6] * Weights[2][0]);
-        Output += (SampleUV[7] * Weights[2][1]);
-        Output += (SampleUV[8] * Weights[2][2]);
+        Output += (SampleUV[0] * Weights._11);
+        Output += (SampleUV[1] * Weights._12);
+        Output += (SampleUV[2] * Weights._13);
+        Output += (SampleUV[3] * Weights._21);
+        Output += (SampleUV[4] * Weights._22);
+        Output += (SampleUV[5] * Weights._23);
+        Output += (SampleUV[6] * Weights._31);
+        Output += (SampleUV[7] * Weights._32);
+        Output += (SampleUV[8] * Weights._33);
         return Output;
     }
 
     void Process_Gradients(in float2 SampleUV[9], inout float4 AreaGrad, inout float4 UVGradient)
     {
         // Calculate center gradient using Prewitt compass operator
-        // https://homepages.inf.ed.ac.uk/rbf/HIPR2/prewitt.htm
         // 0.xy           | 0.zw           | 1.xy           | 1.zw           | 2.xy           | 2.zw           | 3.xy           | 3.zw
         // .......................................................................................................................................
         // -1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 -1.0 | +1.0 -1.0 -1.0 | -1.0 -1.0 -1.0 | -1.0 -1.0 +1.0 |
@@ -512,13 +511,13 @@ namespace Datamosh
         // -1.0 +1.0 +1.0 | -1.0 -1.0 +1.0 | -1.0 -1.0 -1.0 | +1.0 -1.0 -1.0 | +1.0 +1.0 -1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 | +1.0 +1.0 +1.0 |
 
         float4 PrewittUV[4];
-        PrewittUV[0].xy = Prewitt(SampleUV, float3x3(-1.0, -1.0, -1.0, +1.0, -2.0, +1.0, +1.0, +1.0, +1.0));
-        PrewittUV[0].zw = Prewitt(SampleUV, float3x3(+1.0, -1.0, -1.0, +1.0, -2.0, -1.0, +1.0, +1.0, +1.0));
-        PrewittUV[1].xy = Prewitt(SampleUV, float3x3(+1.0, +1.0, -1.0, +1.0, -2.0, -1.0, +1.0, +1.0, -1.0));
+        PrewittUV[0].xy = Prewitt(SampleUV, float3x3(-1.0, +1.0, +1.0, -1.0, -2.0, +1.0, -1.0, +1.0, +1.0));
+        PrewittUV[0].zw = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, -1.0, -2.0, +1.0, -1.0, -1.0, +1.0));
+        PrewittUV[1].xy = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, +1.0, -2.0, +1.0, -1.0, -1.0, -1.0));
         PrewittUV[1].zw = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, +1.0, -2.0, -1.0, +1.0, -1.0, -1.0));
-        PrewittUV[2].xy = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, +1.0, -2.0, +1.0, -1.0, -1.0, -1.0));
-        PrewittUV[2].zw = Prewitt(SampleUV, float3x3(+1.0, +1.0, +1.0, -1.0, -2.0, +1.0, -1.0, -1.0, +1.0));
-        PrewittUV[3].xy = Prewitt(SampleUV, float3x3(-1.0, +1.0, +1.0, -1.0, -2.0, +1.0, -1.0, +1.0, +1.0));
+        PrewittUV[2].xy = Prewitt(SampleUV, float3x3(+1.0, +1.0, -1.0, +1.0, -2.0, -1.0, +1.0, +1.0, -1.0));
+        PrewittUV[2].zw = Prewitt(SampleUV, float3x3(+1.0, -1.0, -1.0, +1.0, -2.0, -1.0, +1.0, +1.0, +1.0));
+        PrewittUV[3].xy = Prewitt(SampleUV, float3x3(-1.0, -1.0, -1.0, +1.0, -2.0, +1.0, +1.0, +1.0, +1.0));
         PrewittUV[3].zw = Prewitt(SampleUV, float3x3(-1.0, -1.0, +1.0, -1.0, -2.0, +1.0, +1.0, +1.0, +1.0));
 
         float2 MaxGradient[3];
@@ -527,7 +526,7 @@ namespace Datamosh
 
         const float Weight = 1.0 / 5.0;
         MaxGradient[2] = max(abs(MaxGradient[0]), abs(MaxGradient[1])) * Weight;
-        float CenterGradient = rsqrt((dot(MaxGradient[2], MaxGradient[2]) * 0.5) + FP16_MINIMUM);
+        float CenterGradient = rsqrt((dot(MaxGradient[2], MaxGradient[2])) + FP16_MINIMUM);
 
         // Area smoothness gradients
         // .............................

--- a/shaders/kDatamosh.fx
+++ b/shaders/kDatamosh.fx
@@ -146,8 +146,8 @@ namespace Datamosh
         #endif
     };
 
-    TEXTURE(Render_Common_1_P, BUFFER_SIZE_1, RG16F, 9)
-    SAMPLER(Sample_Common_1_P, Render_Common_1_P)
+    TEXTURE(Render_Common_1_C, BUFFER_SIZE_1, RG16F, 9)
+    SAMPLER(Sample_Common_1_C, Render_Common_1_C)
 
     TEXTURE(Render_Optical_Flow, BUFFER_SIZE_1, RG16F, 1)
     SAMPLER(Sample_Optical_Flow, Render_Optical_Flow)
@@ -338,7 +338,14 @@ namespace Datamosh
         Gaussian_Blur(Shared_Resources_Datamosh::Sample_Common_1_B, TexCoords, true, OutputColor0);
     }
 
-    void Derivatives_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
+    void Derivatives_Z_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
+    {
+        float2 Current = tex2D(Shared_Resources_Datamosh::Sample_Common_1_A, TexCoord).xy;
+        float2 Previous = tex2D(Sample_Common_1_C, TexCoord).xy;
+        OutputColor0 = dot(Current - Previous, 1.0);
+    }
+
+    void Derivatives_XY_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
     {
         // Bilinear 5x5 Sobel by CeeJayDK
         //   B1 B2
@@ -383,14 +390,8 @@ namespace Datamosh
         const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
-        float2 Current = tex2Dlod(Shared_Resources_Datamosh::Sample_Common_1_A, float4(TexCoord, 0.0, Level + 0.5)).xy;
-        float2 Previous = tex2Dlod(Sample_Common_1_P, float4(TexCoord, 0.0, Level + 0.5)).xy;
-
-        // <Rx, Gx, Ry, Gy>
-        float2 SD = tex2Dlod(Shared_Resources_Datamosh::Sample_Common_1_B, float4(TexCoord, 0.0, Level + 0.5)).xy;
-
-        // <Rz, Gz>
-        float TD = dot(Current - Previous, 1.0);
+        float2 SD = tex2Dlod(Sample_Common_1_C, float4(TexCoord, 0.0, Level + 0.5)).xy;
+        float TD = tex2Dlod(Shared_Resources_Datamosh::Sample_Common_1_B, float4(TexCoord, 0.0, Level + 0.5)).x;
 
         float C = 0.0;
         float2 Aii = 0.0;
@@ -495,14 +496,8 @@ namespace Datamosh
         const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
-        float2 Current = tex2Dlod(Shared_Resources_Datamosh::Sample_Common_1_A, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
-        float2 Previous = tex2Dlod(Sample_Common_1_P, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
-
-        // <Rx, Ry, Gx, Gy>
-        float2 SD = tex2Dlod(Shared_Resources_Datamosh::Sample_Common_1_B, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
-
-        // <Rz, Gz>
-        float TD = dot(Current - Previous, 1.0);
+        float2 SD = tex2Dlod(Sample_Common_1_C, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
+        float TD = tex2Dlod(Shared_Resources_Datamosh::Sample_Common_1_B, float4(TexCoords[1].xz, 0.0, Level + 0.5)).x;
 
         // Optical flow calculation
 
@@ -747,8 +742,9 @@ namespace Datamosh
         PASS(Blur_0_VS, Pre_Blur_0_PS, Shared_Resources_Datamosh::Render_Common_1_B)
         PASS(Blur_1_VS, Pre_Blur_1_PS, Shared_Resources_Datamosh::Render_Common_1_A) // Save this to store later
 
-        // Calculate spatial derivative pyramid
-        PASS(Derivatives_VS, Derivatives_PS, Shared_Resources_Datamosh::Render_Common_1_B)
+        // Calculate spatial and temporal derivative pyramid
+        PASS(Basic_VS, Derivatives_Z_PS, Shared_Resources_Datamosh::Render_Common_1_B)
+        PASS(Derivatives_VS, Derivatives_XY_PS, Render_Common_1_C)
 
         // Bilinear Optical Flow
         PASS(Basic_VS, Level_6_PS, Shared_Resources_Datamosh::Render_Common_6)
@@ -775,7 +771,7 @@ namespace Datamosh
             VertexShader = Blur_0_VS;
             PixelShader = Post_Blur_0_PS;
             RenderTarget0 = Shared_Resources_Datamosh::Render_Common_1_B;
-            RenderTarget1 = Render_Common_1_P;
+            RenderTarget1 = Render_Common_1_C;
         }
 
         pass

--- a/shaders/kDatamosh.fx
+++ b/shaders/kDatamosh.fx
@@ -71,34 +71,28 @@
 
 namespace Shared_Resources_Datamosh
 {
-    // Store convoluted normalized frame 1 and 3
-
     TEXTURE(Render_Common_0, int2(BUFFER_WIDTH >> 1, BUFFER_HEIGHT >> 1), RG16F, 4)
     SAMPLER(Sample_Common_0, Render_Common_0)
-
-    // Normalized, prefiltered frames for processing
 
     TEXTURE(Render_Common_1_A, BUFFER_SIZE_1, RG16F, 9)
     SAMPLER(Sample_Common_1_A, Render_Common_1_A)
 
-    TEXTURE(Render_Common_1_B, BUFFER_SIZE_1, RGBA16F, 9)
+    TEXTURE(Render_Common_1_B, BUFFER_SIZE_1, RG16F, 9)
     SAMPLER(Sample_Common_1_B, Render_Common_1_B)
 
-    // Levels
-
-    TEXTURE(Render_Common_2, BUFFER_SIZE_2, RGBA16F, 1)
+    TEXTURE(Render_Common_2, BUFFER_SIZE_2, RG16F, 1)
     SAMPLER(Sample_Common_2, Render_Common_2)
 
-    TEXTURE(Render_Common_3, BUFFER_SIZE_3, RGBA16F, 1)
+    TEXTURE(Render_Common_3, BUFFER_SIZE_3, RG16F, 1)
     SAMPLER(Sample_Common_3, Render_Common_3)
 
-    TEXTURE(Render_Common_4, BUFFER_SIZE_4, RGBA16F, 1)
+    TEXTURE(Render_Common_4, BUFFER_SIZE_4, RG16F, 1)
     SAMPLER(Sample_Common_4, Render_Common_4)
 
-    TEXTURE(Render_Common_5, BUFFER_SIZE_5, RGBA16F, 1)
+    TEXTURE(Render_Common_5, BUFFER_SIZE_5, RG16F, 1)
     SAMPLER(Sample_Common_5, Render_Common_5)
 
-    TEXTURE(Render_Common_6, BUFFER_SIZE_6, RGBA16F, 1)
+    TEXTURE(Render_Common_6, BUFFER_SIZE_6, RG16F, 1)
     SAMPLER(Sample_Common_6, Render_Common_6)
 }
 
@@ -344,7 +338,7 @@ namespace Datamosh
         Gaussian_Blur(Shared_Resources_Datamosh::Sample_Common_1_B, TexCoords, true, OutputColor0);
     }
 
-    void Derivatives_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
+    void Derivatives_PS(in float4 Position : SV_POSITION, in float4 TexCoords[2] : TEXCOORD0, out float2 OutputColor0 : SV_TARGET0)
     {
         // Bilinear 5x5 Sobel by CeeJayDK
         //   B1 B2
@@ -361,8 +355,10 @@ namespace Datamosh
         float2 C1 = tex2D(Shared_Resources_Datamosh::Sample_Common_1_A, TexCoords[1].yz).xy * 4.0; // <+0.5, -1.5>
 
         OutputColor0 = 0.0;
-        OutputColor0.xz = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
-        OutputColor0.yw = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
+        float2 Ix = ((B2 + A1 + B0 + C1) - (B1 + A0 + A2 + C0)) / 12.0;
+        float2 Iy = ((A0 + B1 + B2 + A1) - (A2 + C0 + C1 + B0)) / 12.0;
+        OutputColor0.x = dot(Ix, 1.0);
+        OutputColor0.y = dot(Iy, 1.0);
     }
 
     /*
@@ -381,41 +377,41 @@ namespace Datamosh
 
     #define COARSEST_LEVEL 5
 
-    void Coarse_Optical_Flow_TV(in float2 TexCoord, in float Level, in float4 UV, out float4 OpticalFlow)
+    void Coarse_Optical_Flow_TV(in float2 TexCoord, in float Level, in float4 UV, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 1e-3) / exp2(COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 Current = tex2Dlod(Shared_Resources_Datamosh::Sample_Common_1_A, float4(TexCoord, 0.0, Level + 0.5)).xy;
         float2 Previous = tex2Dlod(Sample_Common_1_P, float4(TexCoord, 0.0, Level + 0.5)).xy;
 
         // <Rx, Gx, Ry, Gy>
-        float4 SD = tex2Dlod(Shared_Resources_Datamosh::Sample_Common_1_B, float4(TexCoord, 0.0, Level + 0.5));
+        float2 SD = tex2Dlod(Shared_Resources_Datamosh::Sample_Common_1_B, float4(TexCoord, 0.0, Level + 0.5)).xy;
 
         // <Rz, Gz>
-        float2 TD = Current - Previous;
+        float TD = dot(Current - Previous, 1.0);
 
-        float2 C = 0.0;
-        float4 Aii = 0.0;
-        float2 Aij = 0.0;
-        float4 Bi = 0.0;
+        float C = 0.0;
+        float2 Aii = 0.0;
+        float Aij = 0.0;
+        float2 Bi = 0.0;
 
         // Calculate constancy assumption nonlinearity
-        C = rsqrt((TD.rg * TD.rg) + FP16_MINIMUM);
+        C = rsqrt((TD * TD) + FP16_MINIMUM);
 
         // Build linear equation
         // [Aii Aij] [X] = [Bi]
         // [Aij Aii] [Y] = [Bi]
-        Aii = 1.0 / (C.rrgg * (SD.xyzw * SD.xyzw) + Alpha);
-        Aij = C.rg * (SD.xz * SD.yw);
-        Bi = C.rrgg * (SD.xyzw * TD.rrgg);
+        Aii = 1.0 / (C * (SD.xy * SD.xy) + Alpha);
+        Aij = C * (SD.x * SD.y);
+        Bi = C * (SD.xy * TD);
 
         // Solve linear equation for [U, V]
         // [Ix^2+A IxIy] [U] = -[IxIt]
         // [IxIy Iy^2+A] [V] = -[IyIt]
-        OpticalFlow.xz = Aii.xz * ((Alpha * UV.xz) - (Aij.rg * UV.yw) - Bi.xz);
-        OpticalFlow.yw = Aii.yw * ((Alpha * UV.yw) - (Aij.rg * OpticalFlow.xz) - Bi.yw);
+        OpticalFlow.x = Aii.x * ((Alpha * UV.x) - (Aij * UV.y) - Bi.x);
+        OpticalFlow.y = Aii.y * ((Alpha * UV.y) - (Aij * OpticalFlow.x) - Bi.y);
     }
 
     void Gradient(in float4x2 Samples, out float Gradient)
@@ -488,39 +484,37 @@ namespace Datamosh
         UVGradient = 0.5 * (CenterGradient + AreaGrad);
     }
 
-    void Area_Average(in float4 SampleNW, in float4 SampleNE, in float4 SampleSW, in float4 SampleSE, out float4 Color)
+    void Area_Average(in float2 SampleNW, in float2 SampleNE, in float2 SampleSW, in float2 SampleSE, out float2 Color)
     {
         Color = (SampleNW + SampleNE + SampleSW + SampleSE) * 0.25;
     }
 
-    void Optical_Flow_TV(in sampler2D SourceUV, in float4 TexCoords[3], in float Level, out float4 OpticalFlow)
+    void Optical_Flow_TV(in sampler2D SourceUV, in float4 TexCoords[3], in float Level, out float2 OpticalFlow)
     {
         OpticalFlow = 0.0;
-        const float Alpha = max((_Constraint * 1e-3) / exp2(COARSEST_LEVEL - Level), FP16_MINIMUM);
+        const float Alpha = max((_Constraint * 3e-3) / pow(4.0, COARSEST_LEVEL - Level), FP16_MINIMUM);
 
         // Load textures
         float2 Current = tex2Dlod(Shared_Resources_Datamosh::Sample_Common_1_A, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
         float2 Previous = tex2Dlod(Sample_Common_1_P, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
 
-        // <Rx, Gx, Ry, Gy>
-        float4 SD = tex2Dlod(Shared_Resources_Datamosh::Sample_Common_1_B, float4(TexCoords[1].xz, 0.0, Level + 0.5));
+        // <Rx, Ry, Gx, Gy>
+        float2 SD = tex2Dlod(Shared_Resources_Datamosh::Sample_Common_1_B, float4(TexCoords[1].xz, 0.0, Level + 0.5)).xy;
 
         // <Rz, Gz>
-        float2 TD = Current - Previous;
+        float TD = dot(Current - Previous, 1.0);
 
         // Optical flow calculation
 
         // <Ru, Rv, Gu, Gv>
-        float4 SampleUV[9];
-        float2 SampleUVR[9];
-        float2 SampleUVG[9];
+        float2 SampleUV[9];
 
         // [0] = Red, [1] = Green
-        float4 AreaGrad[2];
-        float4 UVGradient[2];
+        float4 AreaGrad;
+        float4 UVGradient;
 
         // <Ru, Rv, Gu, Gv>
-        float4 AreaAvg[4];
+        float2 AreaAvg[4];
         float4 CenterAverage;
         float4 UVAverage;
 
@@ -528,29 +522,20 @@ namespace Datamosh
         // 0 3 6
         // 1 4 7
         // 2 5 8
-        SampleUV[0] = tex2D(SourceUV, TexCoords[0].xy);
-        SampleUV[1] = tex2D(SourceUV, TexCoords[0].xz);
-        SampleUV[2] = tex2D(SourceUV, TexCoords[0].xw);
-        SampleUV[3] = tex2D(SourceUV, TexCoords[1].xy);
-        SampleUV[4] = tex2D(SourceUV, TexCoords[1].xz);
-        SampleUV[5] = tex2D(SourceUV, TexCoords[1].xw);
-        SampleUV[6] = tex2D(SourceUV, TexCoords[2].xy);
-        SampleUV[7] = tex2D(SourceUV, TexCoords[2].xz);
-        SampleUV[8] = tex2D(SourceUV, TexCoords[2].xw);
-
-        [unroll]for(int i = 0; i < 9; i++)
-        {
-            SampleUVR[i] = SampleUV[i].xy;
-            SampleUVG[i] = SampleUV[i].zw;
-        }
+        SampleUV[0] = tex2D(SourceUV, TexCoords[0].xy).xy;
+        SampleUV[1] = tex2D(SourceUV, TexCoords[0].xz).xy;
+        SampleUV[2] = tex2D(SourceUV, TexCoords[0].xw).xy;
+        SampleUV[3] = tex2D(SourceUV, TexCoords[1].xy).xy;
+        SampleUV[4] = tex2D(SourceUV, TexCoords[1].xz).xy;
+        SampleUV[5] = tex2D(SourceUV, TexCoords[1].xw).xy;
+        SampleUV[6] = tex2D(SourceUV, TexCoords[2].xy).xy;
+        SampleUV[7] = tex2D(SourceUV, TexCoords[2].xz).xy;
+        SampleUV[8] = tex2D(SourceUV, TexCoords[2].xw).xy;
 
         // Process area gradients in each patch, per plane
-
-        Process_Gradients(SampleUVR, AreaGrad[0], UVGradient[0]);
-        Process_Gradients(SampleUVG, AreaGrad[1], UVGradient[1]);
+        Process_Gradients(SampleUV, AreaGrad, UVGradient);
 
         // Calculate area + center averages of estimated vectors
-
         Area_Average(SampleUV[0], SampleUV[3], SampleUV[1], SampleUV[4], AreaAvg[0]);
         Area_Average(SampleUV[3], SampleUV[6], SampleUV[4], SampleUV[7], AreaAvg[1]);
         Area_Average(SampleUV[1], SampleUV[4], SampleUV[2], SampleUV[5], AreaAvg[2]);
@@ -561,41 +546,39 @@ namespace Datamosh
         CenterAverage += (SampleUV[4] * 4.0);
         CenterAverage = CenterAverage / 16.0;
 
-        float2 C = 0.0;
-        float4 Aii = 0.0;
-        float2 Aij = 0.0;
-        float4 Bi = 0.0;
+        float C = 0.0;
+        float2 Aii = 0.0;
+        float Aij = 0.0;
+        float2 Bi = 0.0;
 
         // Calculate constancy assumption nonlinearity
         // Dot-product increases when the current gradient + previous estimation are parallel
-        C.r = dot(SD.xy, CenterAverage.xy) + TD.r;
-        C.g = dot(SD.zw, CenterAverage.zw) + TD.g;
-        C.rg = rsqrt((C.rg * C.rg) + FP16_MINIMUM);
+        // IxU + IyV = -It -> IxU + IyV + It = 0.0
+        C = dot(SD.xy, CenterAverage.xy) + TD;
+        C = rsqrt((C * C) + FP16_MINIMUM);
 
         // Build linear equation
         // [Aii Aij] [X] = [Bi]
         // [Aij Aii] [Y] = [Bi]
-        Aii.xy = 1.0 / (dot(UVGradient[0], 1.0) * Alpha + (C.rr * (SD.xy * SD.xy)));
-        Aii.zw = 1.0 / (dot(UVGradient[1], 1.0) * Alpha + (C.gg * (SD.zw * SD.zw)));
-        Aij.xy = C.rg * (SD.xz * SD.yw);
-        Bi = C.rrgg * (SD.xyzw * TD.rrgg);
+        Aii = 1.0 / (dot(UVGradient, 1.0) * Alpha + (C * (SD.xy * SD.xy)));
+        Aij = C * (SD.x * SD.y);
+        Bi = C * (SD.xy * TD);
 
         // Solve linear equation for [U, V]
         // [Ix^2+A IxIy] [U] = -[IxIt]
         // [IxIy Iy^2+A] [V] = -[IyIt]
-        UVAverage.xy = (AreaGrad[0].xx * AreaAvg[0].xy) + (AreaGrad[0].yy * AreaAvg[1].xy) + (AreaGrad[0].zz * AreaAvg[2].xy) + (AreaGrad[0].ww * AreaAvg[3].xy);
-        UVAverage.zw = (AreaGrad[1].xx * AreaAvg[0].zw) + (AreaGrad[1].yy * AreaAvg[1].zw) + (AreaGrad[1].zz * AreaAvg[2].zw) + (AreaGrad[1].ww * AreaAvg[3].zw);
-        OpticalFlow.xz = Aii.xz * ((Alpha * UVAverage.xz) - (Aij.rg * CenterAverage.yw) - Bi.xz);
-        OpticalFlow.yw = Aii.yw * ((Alpha * UVAverage.yw) - (Aij.rg * OpticalFlow.xz) - Bi.yw);
+        UVAverage.xy = (AreaGrad.xx * AreaAvg[0]) + (AreaGrad.yy * AreaAvg[1]) + (AreaGrad.zz * AreaAvg[2]) + (AreaGrad.ww * AreaAvg[3]);
+        OpticalFlow.x = Aii.x * ((Alpha * UVAverage.x) - (Aij * CenterAverage.y) - Bi.x);
+        OpticalFlow.y = Aii.y * ((Alpha * UVAverage.y) - (Aij * OpticalFlow.x) - Bi.y);
     }
 
     #define LEVEL_PS(NAME, SAMPLER, LEVEL)                                                                             \
-        void NAME(in float4 Position : SV_POSITION, in float4 TexCoords[3] : TEXCOORD0, out float4 Color : SV_TARGET0) \
+        void NAME(in float4 Position : SV_POSITION, in float4 TexCoords[3] : TEXCOORD0, out float2 Color : SV_TARGET0) \
         {                                                                                                              \
             Optical_Flow_TV(SAMPLER, TexCoords, LEVEL, Color);                                                         \
         }
 
-    void Level_6_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float4 Color : SV_TARGET0)
+    void Level_6_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float2 Color : SV_TARGET0)
     {
         Coarse_Optical_Flow_TV(TexCoord, 5.0, 0.0, Color);
     }
@@ -607,9 +590,8 @@ namespace Datamosh
 
     void Level_1_PS(in float4 Position : SV_POSITION, in float4 TexCoords[3] : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
-        float4 OpticalFlow = 0.0;
-        Optical_Flow_TV(Shared_Resources_Datamosh::Sample_Common_2, TexCoords, 0.0, OpticalFlow);
-        OutputColor0.rg = OpticalFlow.xy + OpticalFlow.zw;
+        OutputColor0 = 0.0;
+        Optical_Flow_TV(Shared_Resources_Datamosh::Sample_Common_2, TexCoords, 0.0, OutputColor0.xy);
         OutputColor0.ba = float2(0.0, _BlendFactor);
     }
 

--- a/shaders/kDatamosh.fx
+++ b/shaders/kDatamosh.fx
@@ -50,23 +50,23 @@
 #define BUFFER_SIZE_6 int2(ROUND_UP_EVEN(SIZE.x >> 5), ROUND_UP_EVEN(SIZE.y >> 5))
 
 #define TEXTURE(NAME, SIZE, FORMAT, LEVELS) \
-    texture2D NAME                          \
-    {                                       \
-        Width = SIZE.x;                     \
-        Height = SIZE.y;                    \
-        Format = FORMAT;                    \
-        MipLevels = LEVELS;                 \
+    texture2D NAME \
+    { \
+        Width = SIZE.x; \
+        Height = SIZE.y; \
+        Format = FORMAT; \
+        MipLevels = LEVELS; \
     };
 
 #define SAMPLER(NAME, TEXTURE) \
-    sampler2D NAME             \
-    {                          \
-        Texture = TEXTURE;     \
-        AddressU = MIRROR;     \
-        AddressV = MIRROR;     \
-        MagFilter = LINEAR;    \
-        MinFilter = LINEAR;    \
-        MipFilter = LINEAR;    \
+    sampler2D NAME \
+    { \
+        Texture = TEXTURE; \
+        AddressU = MIRROR; \
+        AddressV = MIRROR; \
+        MagFilter = LINEAR; \
+        MinFilter = LINEAR; \
+        MipFilter = LINEAR; \
     };
 
 namespace Shared_Resources_Datamosh
@@ -80,7 +80,7 @@ namespace Shared_Resources_Datamosh
     TEXTURE(Render_Common_1_B, BUFFER_SIZE_1, RG16F, 9)
     SAMPLER(Sample_Common_1_B, Render_Common_1_B)
 
-    TEXTURE(Render_Common_2_A, BUFFER_SIZE_2, RG16F, 8)
+    TEXTURE(Render_Common_2_A, BUFFER_SIZE_2, RG16F, 7)
     SAMPLER(Sample_Common_2_A, Render_Common_2_A)
 
     TEXTURE(Render_Common_2_B, BUFFER_SIZE_2, RG16F, 1)
@@ -117,11 +117,11 @@ namespace Datamosh
     OPTION(int, _BlockSize, "slider", "Datamosh", "Block Size", 4, 32, 16)
     OPTION(float, _Entropy, "slider", "Datamosh", "Entropy", 0.0, 1.0, 0.5)
     OPTION(float, _Contrast, "slider", "Datamosh", "Contrast of stripe-shaped noise", 0.0, 4.0, 2.0)
-    OPTION(float, _Scale, "slider", "Datamosh", "Scale factor for velocity vectors", 0.0, 4.0, 2.0)
+    OPTION(float, _Scale, "slider", "Datamosh", "Scale factor for velocity vectors", 0.0, 2.0, 1.0)
     OPTION(float, _Diffusion, "slider", "Datamosh", "Amount of random displacement", 0.0, 4.0, 2.0)
 
     OPTION(float, _Constraint, "slider", "Optical flow", "Motion constraint", 0.0, 1.0, 0.5)
-    OPTION(float, _MipBias, "slider", "Optical flow", "Optical flow mipmap bias", 0.0, 7.0, 0.0)
+    OPTION(float, _MipBias, "slider", "Optical flow", "Optical flow mipmap bias", 0.0, 6.0, 0.0)
     OPTION(float, _BlendFactor, "slider", "Optical flow", "Temporal blending factor", 0.0, 0.9, 0.5)
 
     #ifndef LINEAR_SAMPLING
@@ -197,65 +197,48 @@ namespace Datamosh
         Position = float4(TexCoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
     }
 
-    static const float4 BlurOffsets[4] =
+    static const float4 BlurOffsets[3] =
     {
-        float4(0.0, 0.0, 0.0, 0.0),
         float4(0.0, 1.490652, 3.4781995, 5.465774),
         float4(0.0, 7.45339, 9.441065, 11.42881),
         float4(0.0, 13.416645, 15.404578, 17.392626)
     };
 
-    void Blur_0_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[7] : TEXCOORD0)
+    void Blur_VS(in bool IsAlt, in float2 PixelSize, in uint ID, inout float4 Position, inout float4 TexCoords[7])
     {
-        float2 CoordVS = 0.0;
-        Basic_VS(ID, Position, CoordVS);
-        TexCoords[0] = CoordVS.xyxy;
+        Basic_VS(ID, Position, TexCoords[0].xy);
 
-        for(int i = 1; i < 4; i++)
+        if (!IsAlt)
         {
-            TexCoords[i] = CoordVS.xyyy + (BlurOffsets[i].xyzw / BUFFER_SIZE_1.xyyy);
-            TexCoords[i + 3] = CoordVS.xyyy - (BlurOffsets[i].xyzw / BUFFER_SIZE_1.xyyy);
+            TexCoords[1] = TexCoords[0].xyyy + (BlurOffsets[0].xyzw / PixelSize.xyyy);
+            TexCoords[2] = TexCoords[0].xyyy + (BlurOffsets[1].xyzw / PixelSize.xyyy);
+            TexCoords[3] = TexCoords[0].xyyy + (BlurOffsets[2].xyzw / PixelSize.xyyy);
+            TexCoords[4] = TexCoords[0].xyyy - (BlurOffsets[0].xyzw / PixelSize.xyyy);
+            TexCoords[5] = TexCoords[0].xyyy - (BlurOffsets[1].xyzw / PixelSize.xyyy);
+            TexCoords[6] = TexCoords[0].xyyy - (BlurOffsets[2].xyzw / PixelSize.xyyy);
         }
+        else
+        {
+            TexCoords[1] = TexCoords[0].xxxy + (BlurOffsets[0].yzwx / PixelSize.xxxy);
+            TexCoords[2] = TexCoords[0].xxxy + (BlurOffsets[1].yzwx / PixelSize.xxxy);
+            TexCoords[3] = TexCoords[0].xxxy + (BlurOffsets[2].yzwx / PixelSize.xxxy);
+            TexCoords[4] = TexCoords[0].xxxy - (BlurOffsets[0].yzwx / PixelSize.xxxy);
+            TexCoords[5] = TexCoords[0].xxxy - (BlurOffsets[1].yzwx / PixelSize.xxxy);
+            TexCoords[6] = TexCoords[0].xxxy - (BlurOffsets[2].yzwx / PixelSize.xxxy);
+        }
+
     }
 
-    void Blur_1_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[7] : TEXCOORD0)
-    {
-        float2 CoordVS = 0.0;
-        Basic_VS(ID, Position, CoordVS);
-        TexCoords[0] = CoordVS.xyxy;
-
-        for(int i = 1; i < 4; i++)
-        {
-            TexCoords[i] = CoordVS.xxxy + (BlurOffsets[i].yzwx / BUFFER_SIZE_1.xxxy);
-            TexCoords[i + 3] = CoordVS.xxxy - (BlurOffsets[i].yzwx / BUFFER_SIZE_1.xxxy);
+    #define BLUR_VS(NAME, IS_ALT, PIXEL_SIZE) \
+        void NAME(in uint ID : SV_VERTEXID, inout float4 Position : SV_POSITION, inout float4 TexCoords[7] : TEXCOORD0) \
+        { \
+            Blur_VS(IS_ALT, PIXEL_SIZE, ID, Position, TexCoords); \
         }
-    }
 
-    void Blur_0_P_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[7] : TEXCOORD0)
-    {
-        float2 CoordVS = 0.0;
-        Basic_VS(ID, Position, CoordVS);
-        TexCoords[0] = CoordVS.xyxy;
-
-        for(int i = 1; i < 4; i++)
-        {
-            TexCoords[i] = CoordVS.xyyy + (BlurOffsets[i].xyzw / BUFFER_SIZE_2.xyyy);
-            TexCoords[i + 3] = CoordVS.xyyy - (BlurOffsets[i].xyzw / BUFFER_SIZE_2.xyyy);
-        }
-    }
-
-    void Blur_1_P_VS(in uint ID : SV_VERTEXID, out float4 Position : SV_POSITION, out float4 TexCoords[7] : TEXCOORD0)
-    {
-        float2 CoordVS = 0.0;
-        Basic_VS(ID, Position, CoordVS);
-        TexCoords[0] = CoordVS.xyxy;
-
-        for(int i = 1; i < 4; i++)
-        {
-            TexCoords[i] = CoordVS.xxxy + (BlurOffsets[i].yzwx / BUFFER_SIZE_2.xxxy);
-            TexCoords[i + 3] = CoordVS.xxxy - (BlurOffsets[i].yzwx / BUFFER_SIZE_2.xxxy);
-        }
-    }
+    BLUR_VS(Pre_Blur_0_VS, false, BUFFER_SIZE_1)
+    BLUR_VS(Pre_Blur_1_VS, true, BUFFER_SIZE_1)
+    BLUR_VS(Post_Blur_0_VS, false, BUFFER_SIZE_2)
+    BLUR_VS(Post_Blur_1_VS, true, BUFFER_SIZE_2)
 
     void Sample_3x3_VS(in uint ID, in float2 TexelSize, out float4 Position, out float4 TexCoords[3])
     {
@@ -729,7 +712,7 @@ namespace Datamosh
 
         // Motion vector
         float2 MotionVectors = tex2Dlod(Sample_Optical_Flow_Post, float4(TexCoord, 0.0, _MipBias)).xy;
-        MotionVectors = MotionVectors * BUFFER_SIZE_1; // Normalized screen space -> Pixel coordinates
+        MotionVectors = MotionVectors * BUFFER_SIZE_2; // Normalized screen space -> Pixel coordinates
         MotionVectors *= _Scale;
         MotionVectors += (Random.xy - 0.5)  * _Diffusion; // Small random displacement (diffusion)
         MotionVectors = round(MotionVectors); // Pixel perfect snapping
@@ -751,7 +734,7 @@ namespace Datamosh
 
     void Datamosh_PS(in float4 Position : SV_POSITION, in float2 TexCoord : TEXCOORD0, out float4 OutputColor0 : SV_TARGET0)
     {
-        const float2 DisplacementTexel = 1.0 / BUFFER_SIZE_1;
+        const float2 DisplacementTexel = 1.0 / BUFFER_SIZE_2;
         const float Quality = 1.0 - _Entropy;
 
         // Random numbers
@@ -801,11 +784,11 @@ namespace Datamosh
     }
 
     #define PASS(VERTEX_SHADER, PIXEL_SHADER, RENDER_TARGET) \
-        pass                                                 \
-        {                                                    \
-            VertexShader = VERTEX_SHADER;                    \
-            PixelShader = PIXEL_SHADER;                      \
-            RenderTarget0 = RENDER_TARGET;                   \
+        pass \
+        { \
+            VertexShader = VERTEX_SHADER; \
+            PixelShader = PIXEL_SHADER; \
+            RenderTarget0 = RENDER_TARGET; \
         }
 
     technique KinoDatamosh
@@ -817,8 +800,8 @@ namespace Datamosh
         PASS(Basic_VS, Blit_Frame_PS, Shared_Resources_Datamosh::Render_Common_1_A)
 
         // Gaussian blur
-        PASS(Blur_0_VS, Pre_Blur_0_PS, Shared_Resources_Datamosh::Render_Common_1_B)
-        PASS(Blur_1_VS, Pre_Blur_1_PS, Shared_Resources_Datamosh::Render_Common_1_A) // Save this to store later
+        PASS(Pre_Blur_0_VS, Pre_Blur_0_PS, Shared_Resources_Datamosh::Render_Common_1_B)
+        PASS(Pre_Blur_1_VS, Pre_Blur_1_PS, Shared_Resources_Datamosh::Render_Common_1_A) // Save this to store later
 
         // Calculate spatial and temporal derivative pyramid
         PASS(Basic_VS, Derivatives_Z_PS, Shared_Resources_Datamosh::Render_Common_1_B)
@@ -847,8 +830,8 @@ namespace Datamosh
         PASS(Basic_VS, Copy_PS, Render_Common_1_C)
 
         // Gaussian blur
-        PASS(Blur_0_P_VS, Post_Blur_0_PS, Shared_Resources_Datamosh::Render_Common_2_B)
-        PASS(Blur_1_P_VS, Post_Blur_1_PS, Shared_Resources_Datamosh::Render_Common_2_A)
+        PASS(Post_Blur_0_VS, Post_Blur_0_PS, Shared_Resources_Datamosh::Render_Common_2_B)
+        PASS(Post_Blur_1_VS, Post_Blur_1_PS, Shared_Resources_Datamosh::Render_Common_2_A)
 
         // Datamoshing
         pass


### PR DESCRIPTION
Changes:
1. Use wider blur, even wider on estimate output
2. Use an expanded, constancy-based algorithm, where we sum the derivatives like [this](https://www.researchgate.net/publication/257067654_Revisiting_Lucas-Kanade_and_Horn-Schunck)
3. Redo matrix math for compass gradient